### PR TITLE
Fix compile issue

### DIFF
--- a/mapf/src/occupancy/mod.rs
+++ b/mapf/src/occupancy/mod.rs
@@ -17,7 +17,7 @@
 
 use std::ops::Sub;
 use std::collections::{HashSet, hash_map, HashMap};
-use bitfield::{Bit, bitfield};
+use bitfield::{Bit, BitMut, bitfield};
 use crate::{
     node::Key,
     util::triangular_for


### PR DESCRIPTION
Currently the main branch fails to compile with the following error:

```
 --> /home/arjo/workspaces/rust/mapf/mapf/src/occupancy/mod.rs:159:14
    |
159 |         self.set_bit(corner.into(), status);
    |              ^^^^^^^ method not found in `&mut CornerStatus`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
18  | use bitfield::BitMut;
    |
```

This tiny commit applies the above change. I will follow this up with a github ci action to check we don't break the main branch. 

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>

P.S. I don't have access rights to this repo and hence had to create a fork,
