### PR TITLE
Updates the GAT syntax

### DIFF
--- a/mapf/src/directed/simple.rs
+++ b/mapf/src/directed/simple.rs
@@ -81,7 +81,7 @@ impl<V: std::fmt::Debug + Clone> crate::Graph for SimpleGraph<V> {
     type Vertex = V;
     type Edge = (usize, usize);
 
-    type EdgeIter<'a> where Self: 'a = impl Iterator<Item=(usize, usize)> + 'a;
+    type EdgeIter<'a>  = impl Iterator<Item=(usize, usize)> + 'a where Self: 'a;
 
     fn vertex (&self, key: usize) -> Option<V> {
         self.vertices.get(key).cloned()

--- a/mapf/src/expander/chain.rs
+++ b/mapf/src/expander/chain.rs
@@ -43,7 +43,7 @@ impl<E: Expander, C: Expander<Node=E::Node>> Expander for Chain<E, C> {
 
 impl<E: Targeted<G>, C: Targeted<G, Node=E::Node>, G: Goal<E::Node>> Targeted<G> for Chain<E, C> {
     type TargetedError = ChainErr<E::TargetedError, C::TargetedError>;
-    type TargetedExpansion<'a> where Self: 'a, G: 'a = impl Iterator<Item=Result<Arc<Self::Node>, Self::TargetedError>> + 'a;
+    type TargetedExpansion<'a>  = impl Iterator<Item=Result<Arc<Self::Node>, Self::TargetedError>> + 'a where Self: 'a, G: 'a;
 
     fn expand<'a>(
         &'a self,
@@ -62,7 +62,7 @@ where
     G: Goal<E::Node>,
 {
     type InitTargetedError = E::InitTargetedError;
-    type InitialTargetedNodes<'a> where Self: 'a, S: 'a, G: 'a = E::InitialTargetedNodes<'a>;
+    type InitialTargetedNodes<'a> = E::InitialTargetedNodes<'a> where Self: 'a, S: 'a, G: 'a;
 
     fn start<'a>(
         &'a self,

--- a/mapf/src/expander/closure.rs
+++ b/mapf/src/expander/closure.rs
@@ -59,7 +59,7 @@ where
     F: Fn(&Arc<N>, &G) -> Exp
 {
     type TargetedError = Err;
-    type TargetedExpansion<'a> where Self: 'a = Exp;
+    type TargetedExpansion<'a> = Exp where Self: 'a;
 
     fn expand<'a>(
         &'a self,

--- a/mapf/src/expander/constrain.rs
+++ b/mapf/src/expander/constrain.rs
@@ -57,7 +57,7 @@ impl<E: Expander, C> Expander for Constrain<E, C> {
 
 impl<E: Targeted<G>, C: TargetedConstraint<E::Node, G>, G: Goal<E::Node>> Targeted<G> for Constrain<E, C> {
     type TargetedError = ConstrainErr<E::TargetedError, C::ConstraintError>;
-    type TargetedExpansion<'a> where Self: 'a, G: 'a = impl Iterator<Item=Result<Arc<Self::Node>, Self::TargetedError>> + 'a;
+    type TargetedExpansion<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::TargetedError>> + 'a where Self: 'a, G: 'a ;
 
     fn expand<'a>(
         &'a self,
@@ -77,7 +77,7 @@ where
     G: Goal<E::Node>,
 {
     type InitTargetedError = ConstrainErr<E::InitTargetedError, C::ConstraintError>;
-    type InitialTargetedNodes<'a> where Self: 'a, S: 'a, G: 'a = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>> + 'a;
+    type InitialTargetedNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>> + 'a where Self: 'a, S: 'a, G: 'a;
 
     fn start<'a>(
         &'a self,

--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#![feature(generic_associated_types, associated_type_bounds, type_alias_impl_trait)]
+#![feature(associated_type_bounds, type_alias_impl_trait)]
 
 pub mod progress;
 

--- a/mapf/src/motion/graph_search.rs
+++ b/mapf/src/motion/graph_search.rs
@@ -291,7 +291,7 @@ where
     P::Reach: Reachable<P::Node, G, P::Waypoint>,
 {
     type TargetedError = ExpansionErrorOf<P, G>;
-    type TargetedExpansion<'a> where P: 'a, G: 'a = impl Iterator<Item=Result<Arc<P::Node>, ExpansionErrorOf<P, G>>> + 'a;
+    type TargetedExpansion<'a> = impl Iterator<Item=Result<Arc<P::Node>, ExpansionErrorOf<P, G>>> + 'a where P: 'a, G: 'a ;
 
     fn expand<'a>(
         &'a self,
@@ -338,7 +338,7 @@ where
 
 impl<P: Policy> Aimless for Expander<P> {
     type AimlessError = ExtrapolatorErrorOf<P>;
-    type AimlessExpansion<'a> where P: 'a = impl Iterator<Item=Result<Arc<P::Node>, Self::AimlessError>> + 'a;
+    type AimlessExpansion<'a> = impl Iterator<Item=Result<Arc<P::Node>, Self::AimlessError>> + 'a where P: 'a;
 
     fn aimless_expand<'a>(
         &'a self,

--- a/mapf/src/motion/hold.rs
+++ b/mapf/src/motion/hold.rs
@@ -60,7 +60,7 @@ impl<W: Waypoint, C: CostCalculator<W>, N> Expander for Hold<W, C, N> {
 
 impl<W: Waypoint, C: CostCalculator<W, Cost=N::Cost>, N: Informed + Movable<W>, G: Goal<N>> Targeted<G> for Hold<W, C, N> {
     type TargetedError = NoError;
-    type TargetedExpansion<'a> where W: 'a, N: 'a, C: 'a, G: 'a = impl Iterator<Item=Result<Arc<N>, NoError>>;
+    type TargetedExpansion<'a> = impl Iterator<Item=Result<Arc<N>, NoError>> where W: 'a, N: 'a, C: 'a, G: 'a ;
 
     fn expand<'a>(
         &'a self,

--- a/mapf/src/motion/r2/graph_search.rs
+++ b/mapf/src/motion/r2/graph_search.rs
@@ -105,7 +105,7 @@ where
     H: Heuristic<G::Key, G::Key, C::Cost>,
 {
     type InitAimlessError = InitErrorR2<G::Key, H::Error>;
-    type InitialAimlessNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitAimlessError>> where G: 'a, C: 'a, H: 'a, S: 'a;
+    type InitialAimlessNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitAimlessError>> + 'a where G: 'a, C: 'a, H: 'a, S: 'a;
 
     fn aimless_start<'a>(
         &'a self,
@@ -141,7 +141,7 @@ where
     H: Heuristic<G::Key, G::Key, C::Cost>,
 {
     type InitTargetedError = InitErrorR2<G::Key, H::Error>;
-    type InitialTargetedNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>> where G: 'a, C: 'a, H: 'a, S: 'a ;
+    type InitialTargetedNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>> + 'a where G: 'a, C: 'a, H: 'a, S: 'a ;
 
     fn start<'a>(
         &'a self,

--- a/mapf/src/motion/r2/graph_search.rs
+++ b/mapf/src/motion/r2/graph_search.rs
@@ -105,7 +105,7 @@ where
     H: Heuristic<G::Key, G::Key, C::Cost>,
 {
     type InitAimlessError = InitErrorR2<G::Key, H::Error>;
-    type InitialAimlessNodes<'a> where G: 'a, C: 'a, H: 'a, S: 'a = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitAimlessError>>;
+    type InitialAimlessNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitAimlessError>> where G: 'a, C: 'a, H: 'a, S: 'a;
 
     fn aimless_start<'a>(
         &'a self,
@@ -141,7 +141,7 @@ where
     H: Heuristic<G::Key, G::Key, C::Cost>,
 {
     type InitTargetedError = InitErrorR2<G::Key, H::Error>;
-    type InitialTargetedNodes<'a> where G: 'a, C: 'a, H: 'a, S: 'a = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>>;
+    type InitialTargetedNodes<'a> = impl Iterator<Item=Result<Arc<Self::Node>, Self::InitTargetedError>> where G: 'a, C: 'a, H: 'a, S: 'a ;
 
     fn start<'a>(
         &'a self,

--- a/mapf/src/motion/reach.rs
+++ b/mapf/src/motion/reach.rs
@@ -35,7 +35,7 @@ pub trait Reachable<Node, Goal, W: Waypoint> {
 pub struct NoReach;
 impl<N, G, W: Waypoint> Reachable<N, G, W> for NoReach {
     type ReachError = NoError;
-    type Reaching<'a> where N: 'a, G: 'a, W: 'a = impl Iterator<Item=Result<Trajectory<W>, NoError>>;
+    type Reaching<'a> = impl Iterator<Item=Result<Trajectory<W>, NoError>> where N: 'a, G: 'a, W: 'a ;
 
     fn reach_for<'a>(&'a self, _: &'a N, _: &'a G) -> Self::Reaching<'a> {
         [].into_iter()

--- a/mapf/src/motion/se2/graph_search.rs
+++ b/mapf/src/motion/se2/graph_search.rs
@@ -298,7 +298,7 @@ where
     H: Heuristic<KeySE2<G::Key, RESOLUTION>, GoalSE2<G::Key>, i64>,
 {
     type InitTargetedError = InitErrorSE2<H::Error>;
-    type InitialTargetedNodes<'a> where G: 'a, C: 'a, H: 'a, S: 'a = impl Iterator<Item=Result<Arc<Node<G::Key, RESOLUTION>>, Self::InitTargetedError>> + 'a;
+    type InitialTargetedNodes<'a> = impl Iterator<Item=Result<Arc<Node<G::Key, RESOLUTION>>, Self::InitTargetedError>> + 'a where G: 'a, C: 'a, H: 'a, S: 'a;
 
     fn start<'a>(
         &'a self,

--- a/mapf/src/motion/se2/graph_search.rs
+++ b/mapf/src/motion/se2/graph_search.rs
@@ -127,7 +127,7 @@ pub struct ReachForLinearSE2 {
 
 impl<GraphKey: Key, const RESOLUTION: u64> Reachable<Node<GraphKey, RESOLUTION>, GoalSE2<GraphKey>, se2::timed_position::Waypoint> for ReachForLinearSE2 {
     type ReachError = NoError;
-    type Reaching<'a> = impl Iterator<Item=Result<se2::LinearTrajectory, NoError>>;
+    type Reaching<'a> = impl Iterator<Item=Result<se2::LinearTrajectory, NoError>> + 'a;
 
     fn reach_for<'a>(&'a self, parent: &'a Node<GraphKey, RESOLUTION>, goal: &'a GoalSE2<GraphKey>) -> Self::Reaching<'a> {
         [parent].into_iter()

--- a/mapf/src/node/closed_set.rs
+++ b/mapf/src/node/closed_set.rs
@@ -102,7 +102,7 @@ impl<N: Weighted + PartialKeyed> Default for PartialKeyedClosedSet<N> {
 }
 
 impl<N: Weighted + PartialKeyed> ClosedSet<N> for PartialKeyedClosedSet<N> {
-    type Iter<'a> where N: 'a = impl Iterator<Item=&'a Arc<N>> + 'a;
+    type Iter<'a> = impl Iterator<Item=&'a Arc<N>> + 'a where N: 'a;
 
     fn close(&mut self, node: &Arc<N>) -> CloseResult<N> {
         if let Some(key) = node.partial_key() {
@@ -169,7 +169,7 @@ impl<N: Weighted + PartialKeyed + Timed> Default for TimeVariantPartialKeyedClos
 }
 
 impl<N: Weighted + PartialKeyed + Timed> ClosedSet<N> for TimeVariantPartialKeyedClosetSet<N> {
-    type Iter<'a> where N: 'a = impl Iterator<Item=&'a Arc<N>> + 'a;
+    type Iter<'a> = impl Iterator<Item=&'a Arc<N>> + 'a where N: 'a ;
 
     fn close(&mut self, node: &Arc<N>) -> CloseResult<N> {
         if let Some(key) = node.partial_key() {

--- a/mapf/src/occupancy/graph.rs
+++ b/mapf/src/occupancy/graph.rs
@@ -86,7 +86,7 @@ impl<G: Grid> Graph for VisibilityGraph<G> {
     type Key = Cell;
     type Vertex = Point;
     type Edge = (Cell, Cell);
-    type EdgeIter<'a> where Self: 'a = impl Iterator<Item=(Cell, Cell)> + 'a;
+    type EdgeIter<'a> = impl Iterator<Item=(Cell, Cell)> + 'a where Self: 'a;
 
     fn vertex(&self, cell: Self::Key) -> Option<Self::Vertex> {
         // We don't bother to filter out occupied cells because those cells will
@@ -162,7 +162,7 @@ impl<G: Grid> Graph for NeighborhoodGraph<G> {
     type Key = Cell;
     type Vertex = Point;
     type Edge = (Cell, Cell);
-    type EdgeIter<'a> where Self: 'a = impl Iterator<Item=(Cell, Cell)> + 'a;
+    type EdgeIter<'a> = impl Iterator<Item=(Cell, Cell)> + 'a where Self: 'a;
 
     fn vertex(&self, cell: Self::Key) -> Option<Self::Vertex> {
         if self.visibility.grid().is_occupied(&cell) {


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/issues/89122, GATs no longer use the `type Typename<'a> where Self: 'a = ... ` syntax rather they move the where to the end.

This PR also fixes lifetimes. Seems like the `type_alias_impl_trait` requires you to specify a lifetime.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>