### PR TITLE
Update cached version dependency

### DIFF
--- a/mapf/Cargo.toml
+++ b/mapf/Cargo.toml
@@ -17,7 +17,7 @@ time-point = "0.1"
 sorted-vec = { git = "https://gitlab.com/grey12/sorted-vec", branch = "master" }
 simba = "*"
 num-complex = "*"
-cached = "0.34"
+cached = "0.36"
 approx = "*"
 num = "*"
 arrayvec = "0.7.1"

--- a/mapf/Cargo.toml
+++ b/mapf/Cargo.toml
@@ -17,7 +17,7 @@ time-point = "0.1"
 sorted-vec = { git = "https://gitlab.com/grey12/sorted-vec", branch = "master" }
 simba = "*"
 num-complex = "*"
-cached = "0.36"
+cached = "0.40"
 approx = "*"
 num = "*"
 arrayvec = "0.7.1"


### PR DESCRIPTION
## Bug fix

### Fixed bug

The old version of cached didn't support wasm builds, hence update to the newest version.

### Fix applied

Ref [here](https://github.com/open-rmf/rmf_site/pull/93) for an end to end test with and without this branch (wasm CI fails unless we use this specific branch).
A followup PR should probably add web and windows CIs to `mapf` to make sure this doesn't happen again