### PR TITLE
Open new feature gate for impl_trait_in_assoc_type

### DIFF
--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#![feature(associated_type_bounds, type_alias_impl_trait, result_flattening)]
+#![feature(associated_type_bounds, type_alias_impl_trait, impl_trait_in_assoc_type, result_flattening)]
 
 pub mod domain;
 

--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -14,7 +14,12 @@
  * limitations under the License.
  *
 */
-#![feature(associated_type_bounds, type_alias_impl_trait, impl_trait_in_assoc_type, result_flattening)]
+#![feature(
+    associated_type_bounds,
+    type_alias_impl_trait,
+    impl_trait_in_assoc_type,
+    result_flattening
+)]
 
 pub mod domain;
 


### PR DESCRIPTION
It seems that 1.71.0-nightly has added a new feature gate for one of the unstable features that we're using. This PR opens up that gate.