### PR TITLE
Pin iced version to fix CI

### DIFF
--- a/mapf-viz/Cargo.toml
+++ b/mapf-viz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 mapf = { path="../mapf" }
 iced = { git = "https://github.com/mxgrey/iced", branch = "asymmetric_scale", features = ["canvas", "smol"] }
-iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "main" }
+iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "v0.1.0" }
 iced_native = { git = "https://github.com/mxgrey/iced", branch = "asymmetric_scale" }
 serde = { version="1.0", features = ["derive"] }
 serde_yaml = "*"

--- a/mapf-viz/src/spatial_canvas.rs
+++ b/mapf-viz/src/spatial_canvas.rs
@@ -168,8 +168,12 @@ impl<Message, Program: SpatialCanvasProgram<Message>> SpatialCanvas<Message, Pro
     }
 
     pub fn camera_bounds(&self) -> InclusionZone {
-        let Some(bounds) = &self.bounds else { return InclusionZone::Empty };
-        let Some(s_inv) = Transform::scale(self.zoom, -self.zoom).inverse() else { return InclusionZone::Empty };
+        let Some(bounds) = &self.bounds else {
+            return InclusionZone::Empty;
+        };
+        let Some(s_inv) = Transform::scale(self.zoom, -self.zoom).inverse() else {
+            return InclusionZone::Empty;
+        };
         let bound_center = Point::new(bounds.width / 2.0, bounds.height / 2.0);
         let p0 = s_inv.transform_point(bound_center - self.offset) - bound_center / self.zoom;
         let p1 = iced::Point::new(
@@ -182,7 +186,9 @@ impl<Message, Program: SpatialCanvasProgram<Message>> SpatialCanvas<Message, Pro
     }
 
     pub fn fit_to_zone(&mut self, zone: InclusionZone) -> bool {
-        let Some(bounds) = &mut self.bounds else { return false };
+        let Some(bounds) = &mut self.bounds else {
+            return false;
+        };
 
         if let InclusionZone::Some { lower, upper } = zone {
             let x_zoom = bounds.width / (upper.x - lower.x);

--- a/mapf/src/negotiation/mod.rs
+++ b/mapf/src/negotiation/mod.rs
@@ -513,7 +513,9 @@ impl NegotiationCloser {
 
     pub fn status<'a>(&'a self, node: &NegotiationNode) -> ClosedStatus<'a, ()> {
         let mut key_iter = node.keys.iter();
-        let Some(first_key) = key_iter.next() else { return ClosedStatus::Open };
+        let Some(first_key) = key_iter.next() else {
+            return ClosedStatus::Open;
+        };
 
         let mut candidates: HashSet<usize> = HashSet::from_iter(
             self.closed_set
@@ -528,7 +530,9 @@ impl NegotiationCloser {
                 break;
             }
 
-            let Some(new_candidates) = self.closed_set.get(next_key) else { return ClosedStatus::Open };
+            let Some(new_candidates) = self.closed_set.get(next_key) else {
+                return ClosedStatus::Open;
+            };
             candidates.retain(|c| new_candidates.contains(c));
         }
 
@@ -862,7 +866,9 @@ fn reconsider_negotiations(
     let mut merge_old_negotiation_into_new: HashMap<usize, HashSet<usize>> = HashMap::new();
     for (i, negotiation) in &new_negotiations {
         for agent in &negotiation.participants {
-            let Some(n_prev) = previous_negotiation_of_agent.get(agent).cloned() else { continue };
+            let Some(n_prev) = previous_negotiation_of_agent.get(agent).cloned() else {
+                continue;
+            };
             merge_old_negotiation_into_new
                 .entry(n_prev)
                 .or_default()


### PR DESCRIPTION
## Bug fix

### Fixed bug

This crate has been failing to compile for some time since it pointed to specific git versions, from a fork, of the `iced` crate but pointed to upstream main for a related crate `iced_aw`, which is a moving target and eventually became incompatible.

### Fix applied

Pin the `iced_aw` dependency to the 0.1.0 version which is the one that depends on iced 0.3.0 on the pointed forks.
I haven't looked into whether it is possible to migrate out of the fork but it seems the upstream library changed quite dramatically so it might not be too simple.