### PR TITLE
Temporary workaround for typename size limits

### DIFF
--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -20,12 +20,11 @@
     impl_trait_in_assoc_type,
     result_flattening
 )]
-
 // TODO(@mxgrey): Eliminate the need for this by reducing the complexity of
 // struct names, e.g. the typename for the complex chain that implements Lifted
 // in activity.rs. This will probably go hand-in-hand with removing the need for
 // nightly features, and improve compile times all at once.
-#![type_length_limit="157633981"]
+#![type_length_limit = "157633981"]
 
 pub mod domain;
 

--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -21,6 +21,12 @@
     result_flattening
 )]
 
+// TODO(@mxgrey): Eliminate the need for this by reducing the complexity of
+// struct names, e.g. the typename for the complex chain that implements Lifted
+// in activity.rs. This will probably go hand-in-hand with removing the need for
+// nightly features, and improve compile times all at once.
+#![type_length_limit="157633981"]
+
 pub mod domain;
 
 pub mod planner;


### PR DESCRIPTION
This should fix CI by inflating the limit for typename sizes. This is only meant to be a temporary workaround until I have time to refactor the library so it no longer depends on implicit typenames which are generated by nightly features.