### PR TITLE
Fix #27: Panic was being caused by invalid access to bitfield

### DIFF
--- a/mapf/src/graph/occupancy/accessibility_graph.rs
+++ b/mapf/src/graph/occupancy/accessibility_graph.rs
@@ -192,13 +192,14 @@ pub struct CellDirectionsIter {
 impl Iterator for CellDirectionsIter {
     type Item = [i64; 2];
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next_dir > u8::MAX as u16 {
+        if self.next_dir > 7 {
+            // We have already iterated over all the directions
             return None;
         }
 
         while self.directions.bit(self.next_dir as usize) != self.accessibility {
             self.next_dir += 1;
-            if self.next_dir > u8::MAX as u16 {
+            if self.next_dir > 7 {
                 return None;
             }
         }


### PR DESCRIPTION
## Bug fix

### Fixed bug

See #27

I'm not sure why this was not panicking earlier. 

### Fix applied

I think the root cause of #27 is this. I'm not sure why it was not being triggered earlier, but seems like we are accessing an 8 bit bitfield but limiting the index to `u8::MAX`instead of 7.

