### PR TITLE
Migrate to the stable Rust toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,6 @@ jobs:
         .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --default-toolchain=none
         del rustup-init.exe
 
-    - name: Set Rust version to nightly
-      run: rustup default nightly
-
     - name: Add Windows target
       if: matrix.runs-on == 'windows'
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
         cargo -V
         rustup target add x86_64-pc-windows-msvc
 
+    - name: Add ubuntu dependencies
+      if: matrix.runs-on == 'ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libglib2.0-dev
+
+
     - name: Cache Cargo
       uses: actions/cache@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.runs-on == 'ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install libglib2.0-dev libatk-bridge2.0-dev
+        sudo apt-get install libglib2.0-dev libatk-bridge2.0-dev libgtk-3-dev
 
 
     - name: Cache Cargo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.runs-on == 'ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install libglib2.0-dev
+        sudo apt-get install libglib2.0-dev libatk-bridge2.0-dev
 
 
     - name: Cache Cargo

--- a/mapf-viz/Cargo.toml
+++ b/mapf-viz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapf-viz"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mapf-viz/Cargo.toml
+++ b/mapf-viz/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version="1.0", features = ["derive"] }
 serde_yaml = "*"
 async-std = "1.0"
 directories-next = "2.0"
-native-dialog = "*"
+rfd = "0.12"
 derivative = "*"
 lyon = "*"
 nalgebra = "*"

--- a/mapf-viz/examples/grid.rs
+++ b/mapf-viz/examples/grid.rs
@@ -28,7 +28,10 @@ use iced::{
 };
 use iced_native;
 use mapf::{
-    algorithm::{tree::{NodeContainer, IntoIterSorted}, AStarConnect, QueueLength, SearchStatus},
+    algorithm::{
+        tree::{IntoIterSorted, NodeContainer},
+        AStarConnect, QueueLength, SearchStatus,
+    },
     graph::{
         occupancy::{Accessibility, AccessibilityGraph, Cell, Grid, SparseGrid},
         SharedGraph,

--- a/mapf/Cargo.toml
+++ b/mapf/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["mapf", "multi", "agent", "planning", "search"]
 maintenance = {status = "experimental"}
 
 [dependencies]
-mapf_derive = { path = "macros", version = "0.2.0" }
 nalgebra = "0.31.1"
 time-point = "0.1"
 sorted-vec = "0.8.2"

--- a/mapf/Cargo.toml
+++ b/mapf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapf"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Base traits and utilities for multi-agent planning"
 license = "Apache-2.0"
@@ -11,6 +11,7 @@ keywords = ["mapf", "multi", "agent", "planning", "search"]
 maintenance = {status = "experimental"}
 
 [dependencies]
+mapf_derive = { path = "macros", version = "0.2.0" }
 nalgebra = "0.31.1"
 time-point = "0.1"
 sorted-vec = "0.8.2"

--- a/mapf/src/algorithm/a_star.rs
+++ b/mapf/src/algorithm/a_star.rs
@@ -95,9 +95,9 @@ impl<D> AStar<D> {
 
 impl<D> AStar<D>
 where
-    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::ActivityAction>,
+    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::Action>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::WeightedError: Into<D::Error>,
     D::Cost: Ord + Add<Output = D::Cost> + Clone,
 {
@@ -147,10 +147,10 @@ where
         domain: &D,
         closed_set: &mut D::ClosedSet<usize>,
         queue: &mut TreeFrontierQueue<D::Cost>,
-        arena: &Vec<Node<D::State, D::ActivityAction, D::Cost>>,
+        arena: &Vec<Node<D::State, D::Action, D::Cost>>,
         goal: &Goal,
     ) -> Result<
-        Flow<(usize, Node<D::State, D::ActivityAction, D::Cost>), D>,
+        Flow<(usize, Node<D::State, D::Action, D::Cost>), D>,
         AStarSearchError<D::Error>,
     >
     where
@@ -193,12 +193,12 @@ where
         domain: &D,
         memory: &mut <Self as Algorithm>::Memory,
         parent_id: usize,
-        parent: &Node<D::State, D::ActivityAction, D::Cost>,
+        parent: &Node<D::State, D::Action, D::Cost>,
         goal: &Goal,
     ) -> Result<(), AStarSearchError<D::Error>>
     where
         D: Activity<D::State>,
-        D::ActivityAction: Into<D::ActivityAction>,
+        D::Action: Into<D::Action>,
         D::ActivityError: Into<D::Error>,
         D: Informed<D::State, Goal, CostEstimate = D::Cost>,
         D::InformedError: Into<D::Error>,
@@ -227,7 +227,7 @@ where
         parent_id: usize,
         parent_state: &D::State,
         parent_cost: &D::Cost,
-        action: D::ActivityAction,
+        action: D::Action,
         child_state: D::State,
         goal: &Goal,
     ) -> Result<(), AStarSearchError<D::Error>>
@@ -267,9 +267,9 @@ where
 
 impl<D> Algorithm for AStar<D>
 where
-    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::ActivityAction>,
+    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::Action>,
 {
-    type Memory = Memory<D::ClosedSet<usize>, D::State, D::ActivityAction, D::Cost>;
+    type Memory = Memory<D::ClosedSet<usize>, D::State, D::Action, D::Cost>;
 }
 
 impl<D, Start, Goal> Coherent<Start, Goal> for AStar<D>
@@ -278,10 +278,10 @@ where
         + Initializable<Start, Goal, D::State>
         + Closable<D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Informed<D::State, Goal, CostEstimate = D::Cost>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Cost: Ord + Add<Output = D::Cost> + Clone,
     D::InitialError: Into<D::Error>,
     D::WeightedError: Into<D::Error>,
@@ -299,11 +299,11 @@ where
     D: Domain
         + Closable<D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Informed<D::State, Goal, CostEstimate = D::Cost>
         + Satisfiable<D::State, Goal>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Error: Into<Anyhow>,
     D::Cost: Ord + Add<Output = D::Cost> + Clone,
     D::SatisfactionError: Into<D::Error>,
@@ -311,7 +311,7 @@ where
     D::WeightedError: Into<D::Error>,
     D::InformedError: Into<D::Error>,
 {
-    type Solution = Path<D::State, D::ActivityAction, D::Cost>;
+    type Solution = Path<D::State, D::Action, D::Cost>;
     type StepError = AStarSearchError<D::Error>;
 
     fn step(
@@ -348,9 +348,9 @@ impl<D: Configurable> Configurable for AStar<D> {
 
 impl<D> Algorithm for AStarConnect<D>
 where
-    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::ActivityAction>,
+    D: Domain + Closable<D::State> + Activity<D::State> + Weighted<D::State, D::Action>,
 {
-    type Memory = Memory<D::ClosedSet<usize>, D::State, D::ActivityAction, D::Cost>;
+    type Memory = Memory<D::ClosedSet<usize>, D::State, D::Action, D::Cost>;
 }
 
 impl<D, Start, Goal> Coherent<Start, Goal> for AStarConnect<D>
@@ -359,10 +359,10 @@ where
         + Initializable<Start, Goal, D::State>
         + Closable<D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Informed<D::State, Goal, CostEstimate = D::Cost>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Cost: Ord + Add<Output = D::Cost> + Clone,
     D::InitialError: Into<D::Error>,
     D::WeightedError: Into<D::Error>,
@@ -380,12 +380,12 @@ where
     D: Domain
         + Closable<D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Informed<D::State, Goal, CostEstimate = D::Cost>
         + Satisfiable<D::State, Goal>
-        + Connectable<D::State, D::ActivityAction, Goal>,
+        + Connectable<D::State, D::Action, Goal>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Cost: Ord + Add<Output = D::Cost> + Clone,
     D::SatisfactionError: Into<D::Error>,
     D::ActivityError: Into<D::Error>,
@@ -393,7 +393,7 @@ where
     D::InformedError: Into<D::Error>,
     D::ConnectionError: Into<D::Error>,
 {
-    type Solution = Path<D::State, D::ActivityAction, D::Cost>;
+    type Solution = Path<D::State, D::Action, D::Cost>;
     type StepError = AStarSearchError<D::Error>;
 
     fn step(
@@ -497,9 +497,9 @@ where
 /// Control flow return value for functions that constitute step()
 enum Flow<T, D>
 where
-    D: Domain + Activity<D::State> + Weighted<D::State, D::ActivityAction>,
+    D: Domain + Activity<D::State> + Weighted<D::State, D::Action>,
     // D::Error: StdError,
 {
     Proceed(T),
-    Return(SearchStatus<Path<D::State, D::ActivityAction, D::Cost>>),
+    Return(SearchStatus<Path<D::State, D::Action, D::Cost>>),
 }

--- a/mapf/src/algorithm/a_star.rs
+++ b/mapf/src/algorithm/a_star.rs
@@ -149,10 +149,7 @@ where
         queue: &mut TreeFrontierQueue<D::Cost>,
         arena: &Vec<Node<D::State, D::Action, D::Cost>>,
         goal: &Goal,
-    ) -> Result<
-        Flow<(usize, Node<D::State, D::Action, D::Cost>), D>,
-        AStarSearchError<D::Error>,
-    >
+    ) -> Result<Flow<(usize, Node<D::State, D::Action, D::Cost>), D>, AStarSearchError<D::Error>>
     where
         D: Satisfiable<D::State, Goal> + Activity<D::State>,
         D::SatisfactionError: Into<D::Error>,

--- a/mapf/src/algorithm/dijkstra/backward.rs
+++ b/mapf/src/algorithm/dijkstra/backward.rs
@@ -36,7 +36,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     backward: Dijkstra<D>,
@@ -47,7 +47,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     pub fn new(domain: &D) -> Result<Self, D::ReversalError> {
@@ -66,7 +66,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     type Memory = BackwardMemory<D>;
@@ -77,7 +77,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     backward: Memory<D>,
@@ -89,12 +89,12 @@ where
         + Keyring<D::State>
         + Initializable<Goal, Start, D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>
-        + Connectable<D::State, D::ActivityAction, D::Key>
+        + Connectable<D::State, D::Action, D::Key>
         + ArrivalKeyring<D::Key, Goal, Start>,
     D::ClosedSet<usize>: ClosedStatusForKey<D::Key, usize>,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::InitialError: Into<D::Error>,
     D::ArrivalKeyError: Into<D::Error>,
     D::WeightedError: Into<D::Error>,
@@ -118,13 +118,13 @@ where
     D: Domain
         + Reversible
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Keyring<D::State>
         + Closable<D::State>
-        + Connectable<D::State, D::ActivityAction, D::Key>
-        + Backtrack<D::State, D::ActivityAction>,
+        + Connectable<D::State, D::Action, D::Key>
+        + Backtrack<D::State, D::Action>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Cost: Clone + Ord + Add<D::Cost, Output = D::Cost>,
     D::ClosedSet<usize>: ClosedStatusForKey<D::Key, usize>,
     D::ActivityError: Into<D::Error>,
@@ -132,7 +132,7 @@ where
     D::ConnectionError: Into<D::Error>,
     D::BacktrackError: Into<D::Error>,
 {
-    type Solution = Path<D::State, D::ActivityAction, D::Cost>;
+    type Solution = Path<D::State, D::Action, D::Cost>;
     type StepError = DijkstraSearchError<D::Error>;
 
     fn step(
@@ -159,7 +159,7 @@ where
         + Reversible
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
     D::ReversalError: Into<Anyhow>,
 {

--- a/mapf/src/algorithm/dijkstra/backward.rs
+++ b/mapf/src/algorithm/dijkstra/backward.rs
@@ -33,22 +33,14 @@ use std::ops::Add;
 
 pub struct BackwardDijkstra<D: Reversible>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     backward: Dijkstra<D>,
 }
 
 impl<D: Reversible> BackwardDijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     pub fn new(domain: &D) -> Result<Self, D::ReversalError> {
         Ok(Self {
@@ -63,22 +55,14 @@ where
 
 impl<D: Reversible> Algorithm for BackwardDijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     type Memory = BackwardMemory<D>;
 }
 
 pub struct BackwardMemory<D: Reversible>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     backward: Memory<D>,
 }

--- a/mapf/src/algorithm/dijkstra/forward.rs
+++ b/mapf/src/algorithm/dijkstra/forward.rs
@@ -36,7 +36,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     domain: D,
@@ -48,7 +48,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     type Memory = Memory<D>;
@@ -59,7 +59,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     pub fn new(domain: D) -> Self {
@@ -99,12 +99,12 @@ where
         + Keyring<D::State>
         + Initializable<Start, Goal, D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>
-        + Connectable<D::State, D::ActivityAction, D::Key>
+        + Connectable<D::State, D::Action, D::Key>
         + ArrivalKeyring<D::Key, Start, Goal>,
     D::ClosedSet<usize>: ClosedStatusForKey<D::Key, usize>,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::InitialError: Into<D::Error>,
     D::ArrivalKeyError: Into<D::Error>,
     D::WeightedError: Into<D::Error>,
@@ -236,18 +236,18 @@ where
     D: Domain
         + Keyring<D::State>
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>
-        + Connectable<D::State, D::ActivityAction, D::Key>,
+        + Connectable<D::State, D::Action, D::Key>,
     D::State: Clone,
-    D::ActivityAction: Clone,
+    D::Action: Clone,
     D::Cost: Clone + Ord + Add<D::Cost, Output = D::Cost>,
     D::ClosedSet<usize>: ClosedStatusForKey<D::Key, usize>,
     D::ActivityError: Into<D::Error>,
     D::WeightedError: Into<D::Error>,
     D::ConnectionError: Into<D::Error>,
 {
-    type Solution = Path<D::State, D::ActivityAction, D::Cost>;
+    type Solution = Path<D::State, D::Action, D::Cost>;
     type StepError = DijkstraSearchError<D::Error>;
 
     fn step(
@@ -283,7 +283,7 @@ where
                     if Some(closed_set_len) != mt.last_known_closed_len {
                         // The tree was grown by another search, so let's check
                         // if we already found a solution.
-                        let mut best_solution: Option<Path<D::State, D::ActivityAction, D::Cost>> =
+                        let mut best_solution: Option<Path<D::State, D::Action, D::Cost>> =
                             None;
                         for goal_key in &memory.goal_keys {
                             match tree.closed_set.status_for_key(goal_key) {
@@ -479,7 +479,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     type Configuration = D::Configuration;
@@ -523,7 +523,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     trees: HashMap<D::Key, SharedCachedTree<D>>,
@@ -534,7 +534,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     fn default() -> Self {
@@ -552,16 +552,16 @@ type SharedCachedTree<D> = Arc<RwLock<CachedTree<D>>>;
 
 pub struct CachedTree<D>
 where
-    D: Domain + Activity<D::State> + Weighted<D::State, D::ActivityAction> + Closable<D::State>,
+    D: Domain + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     /// The tree data that has been cached
-    tree: Tree<D::ClosedSet<usize>, Node<D::State, D::ActivityAction, D::Cost>, D::Cost>,
+    tree: Tree<D::ClosedSet<usize>, Node<D::State, D::Action, D::Cost>, D::Cost>,
     decisive_closed_nodes: Vec<usize>,
 }
 
 impl<D> CachedTree<D>
 where
-    D: Domain + Activity<D::State> + Weighted<D::State, D::ActivityAction> + Closable<D::State>,
+    D: Domain + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     fn new(closed_set: D::ClosedSet<usize>) -> Self
     where
@@ -575,7 +575,7 @@ where
 
     pub fn tree(
         &self,
-    ) -> &Tree<D::ClosedSet<usize>, Node<D::State, D::ActivityAction, D::Cost>, D::Cost> {
+    ) -> &Tree<D::ClosedSet<usize>, Node<D::State, D::Action, D::Cost>, D::Cost> {
         &self.tree
     }
 }
@@ -585,7 +585,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     /// Trees that are being grown for this search.
@@ -609,7 +609,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     fn new(trees: Vec<TreeMemory<D>>, goal_keys: Vec<D::Key>) -> Self {
@@ -628,7 +628,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     /// A reference to the cache entry that is being searched.
@@ -638,7 +638,7 @@ where
     /// tree in the interim.
     last_known_closed_len: Option<usize>,
     /// Tracks whether a solution was found for this tree.
-    solution: Option<Path<D::State, D::ActivityAction, D::Cost>>,
+    solution: Option<Path<D::State, D::Action, D::Cost>>,
 }
 
 impl<D> TreeMemory<D>
@@ -646,7 +646,7 @@ where
     D: Domain
         + Keyed
         + Activity<D::State>
-        + Weighted<D::State, D::ActivityAction>
+        + Weighted<D::State, D::Action>
         + Closable<D::State>,
 {
     fn new(tree: SharedCachedTree<D>) -> Self {

--- a/mapf/src/algorithm/dijkstra/forward.rs
+++ b/mapf/src/algorithm/dijkstra/forward.rs
@@ -33,11 +33,7 @@ use std::{
 
 pub struct Dijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     domain: D,
     cache: Arc<Mutex<Cache<D>>>,
@@ -45,22 +41,14 @@ where
 
 impl<D> Algorithm for Dijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     type Memory = Memory<D>;
 }
 
 impl<D> Dijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     pub fn new(domain: D) -> Self {
         Self {
@@ -283,8 +271,7 @@ where
                     if Some(closed_set_len) != mt.last_known_closed_len {
                         // The tree was grown by another search, so let's check
                         // if we already found a solution.
-                        let mut best_solution: Option<Path<D::State, D::Action, D::Cost>> =
-                            None;
+                        let mut best_solution: Option<Path<D::State, D::Action, D::Cost>> = None;
                         for goal_key in &memory.goal_keys {
                             match tree.closed_set.status_for_key(goal_key) {
                                 ClosedStatus::Open => {
@@ -476,11 +463,7 @@ where
 /// previous search remains valid.
 impl<D: Configurable> Configurable for Dijkstra<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     type Configuration = D::Configuration;
     fn configure<F>(self, f: F) -> Result<Self, Anyhow>
@@ -520,22 +503,14 @@ impl From<TreeError> for DijkstraImplError {
 #[derive(Clone)]
 struct Cache<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     trees: HashMap<D::Key, SharedCachedTree<D>>,
 }
 
 impl<D> Default for Cache<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     fn default() -> Self {
         Self {
@@ -573,20 +548,14 @@ where
         }
     }
 
-    pub fn tree(
-        &self,
-    ) -> &Tree<D::ClosedSet<usize>, Node<D::State, D::Action, D::Cost>, D::Cost> {
+    pub fn tree(&self) -> &Tree<D::ClosedSet<usize>, Node<D::State, D::Action, D::Cost>, D::Cost> {
         &self.tree
     }
 }
 
 pub struct Memory<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     /// Trees that are being grown for this search.
     // TODO(@mxgrey): Consider using a SmallVec here to avoid heap allocation
@@ -606,11 +575,7 @@ where
 
 impl<D> Memory<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     fn new(trees: Vec<TreeMemory<D>>, goal_keys: Vec<D::Key>) -> Self {
         Self {
@@ -625,11 +590,7 @@ where
 
 pub struct TreeMemory<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     /// A reference to the cache entry that is being searched.
     tree: SharedCachedTree<D>,
@@ -643,11 +604,7 @@ where
 
 impl<D> TreeMemory<D>
 where
-    D: Domain
-        + Keyed
-        + Activity<D::State>
-        + Weighted<D::State, D::Action>
-        + Closable<D::State>,
+    D: Domain + Keyed + Activity<D::State> + Weighted<D::State, D::Action> + Closable<D::State>,
 {
     fn new(tree: SharedCachedTree<D>) -> Self {
         Self {

--- a/mapf/src/algorithm/path.rs
+++ b/mapf/src/algorithm/path.rs
@@ -144,7 +144,7 @@ impl<S, A, C> Path<S, A, C> {
     }
 
     /// Make a trajectory out of this path if possible. If producing a path is
-    /// not possible because no motion is necessary, then creating a trajectory
+    /// not possible because no motion is necessary, then create a trajectory
     /// that holds the agent in place at the start location for the given
     /// `hold_duration`.
     ///

--- a/mapf/src/algorithm/tree.rs
+++ b/mapf/src/algorithm/tree.rs
@@ -236,3 +236,32 @@ where
         self.queue.peek().map(|n| n.0.evaluation.clone())
     }
 }
+
+/// This is implemented based off of
+/// `std::collections::binary_head::IntoIterSorted` which is an unstable feature
+/// of the standard library.
+pub struct BinaryHeapIntoIterSorted<T> {
+    inner: BinaryHeap<T>,
+}
+
+impl<T: Ord> Iterator for BinaryHeapIntoIterSorted<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.pop()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = self.inner.len();
+        (exact, Some(exact))
+    }
+}
+
+pub trait IntoIterSorted<T> {
+    fn binary_heap_into_iter_sorted(self) -> BinaryHeapIntoIterSorted<T>;
+}
+
+impl<T: Ord> IntoIterSorted<T> for BinaryHeap<T> {
+    fn binary_heap_into_iter_sorted(self) -> BinaryHeapIntoIterSorted<T> {
+        BinaryHeapIntoIterSorted { inner: self }
+    }
+}

--- a/mapf/src/domain.rs
+++ b/mapf/src/domain.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,53 +16,75 @@
 */
 
 /// A domain that is being planned over must, at a minimum, specify a type for
-/// its state representation and what kind of actions can be performed.
+/// its state representation and a type for errors that may occur while using
+/// the domain.
 ///
-/// Use DefineTrait<S, A> to construct the traits of a domain using the trait
-/// impls provided by mapf or by using your own custom defined trait impls.
+/// Domains may also implement various traits like [`Activity`], [`Weighted`],
+/// and [`Informed`] which can be used by planners to search the domain. You can
+/// easily gather implementations for these traits into a domain using the
+/// `#[derive(Domain)]` macro.
 ///
-/// Domain trait impls that are provided by mapf out-of-the-box can be found in
-/// the sub-modules of this domain module, such as Activity and Dynamics.
+///
 pub trait Domain {
+    /// Data structure that represents a state within this domain.
     type State;
+
+    /// The error type that this domain may produce from its various operations.
     type Error;
 }
 
-pub mod action_map;
-pub mod activity;
-pub mod closable;
-pub mod configurable;
-pub mod conflict;
-pub mod connectable;
-pub mod cost;
-pub mod define_trait;
-pub mod domain_map;
-pub mod extrapolator;
-pub mod informed;
-pub mod initializable;
-pub mod keyed;
-pub mod reversible;
-pub mod satisfiable;
-pub mod space;
-pub mod state_map;
-pub mod weighted;
+pub use mapf_derive::Domain;
 
+pub mod action_map;
 pub use action_map::*;
+
+pub mod activity;
 pub use activity::*;
+
+pub mod closable;
 pub use closable::*;
-pub use closable::*;
+
+pub mod configurable;
 pub use configurable::*;
+
+pub mod conflict;
 pub use conflict::*;
+
+pub mod connectable;
 pub use connectable::*;
+
+pub mod cost;
 pub use cost::Cost;
+
+pub mod define_trait;
 pub use define_trait::*;
+
+pub mod domain_map;
 pub use domain_map::*;
+
+pub mod extrapolator;
 pub use extrapolator::*;
+
+pub mod informed;
 pub use informed::*;
+
+pub mod initializable;
 pub use initializable::*;
+
+pub mod keyed;
 pub use keyed::*;
+
+pub mod reversible;
 pub use reversible::*;
+
+pub mod satisfiable;
 pub use satisfiable::*;
+
+pub mod space;
 pub use space::*;
+
+pub mod state_map;
 pub use state_map::*;
+
+pub mod weighted;
 pub use weighted::*;

--- a/mapf/src/domain.rs
+++ b/mapf/src/domain.rs
@@ -33,7 +33,7 @@ pub trait Domain {
     type Error;
 }
 
-pub use mapf_derive::Domain;
+// pub use mapf_derive::Domain;
 
 pub mod action_map;
 pub use action_map::*;

--- a/mapf/src/domain/activity.rs
+++ b/mapf/src/domain/activity.rs
@@ -16,7 +16,7 @@
 */
 
 use super::*;
-use crate::{error::NoError, util::FlatResultMapTrait};
+use crate::error::NoError;
 
 /// The Activity trait describes an activity that can be performed within a
 /// domain. An activity yields action choices for an agent where those choices
@@ -515,7 +515,7 @@ mod tests {
     impl Activity<u64> for Count {
         type Action = Interval;
         type ActivityError = NoError;
-        type Choices<'a> = impl Iterator<Item = Result<(Interval, u64), NoError>> + 'a;
+        type Choices<'a> = Vec<Result<(Interval, u64), NoError>>;
 
         fn choices<'a>(&'a self, s: u64) -> Self::Choices<'a>
         where
@@ -527,6 +527,7 @@ mod tests {
             self.by_interval
                 .iter()
                 .map(move |interval| Ok((Interval(*interval), s + *interval)))
+                .collect()
         }
     }
 
@@ -534,8 +535,7 @@ mod tests {
     impl ActivityModifier<u64, Interval> for Multiplier {
         type ModifiedAction = Interval;
         type ModifiedActionError = NoError;
-        type ModifiedChoices<'a> =
-            impl IntoIterator<Item = Result<(Interval, u64), Self::ModifiedActionError>> + 'a;
+        type ModifiedChoices<'a> = [Result<(Interval, u64), Self::ModifiedActionError>; 1];
         fn modify_action<'a>(
             &'a self,
             from_state: u64,
@@ -555,8 +555,7 @@ mod tests {
     impl ActivityModifier<u64, Interval> for DoubleTheOdds {
         type ModifiedAction = Interval;
         type ModifiedActionError = NoError;
-        type ModifiedChoices<'a> =
-            impl IntoIterator<Item = Result<(Interval, u64), Self::ModifiedActionError>> + 'a;
+        type ModifiedChoices<'a> = [Result<(Interval, u64), Self::ModifiedActionError>; 1];
         fn modify_action<'a>(
             &'a self,
             from_state: u64,
@@ -587,8 +586,7 @@ mod tests {
     impl ActivityModifier<u64, Interval> for MapToTestError {
         type ModifiedAction = Interval;
         type ModifiedActionError = TestError;
-        type ModifiedChoices<'a> =
-            impl IntoIterator<Item = Result<(Interval, u64), Self::ModifiedActionError>> + 'a;
+        type ModifiedChoices<'a> = [Result<(Interval, u64), Self::ModifiedActionError>; 1];
         fn modify_action<'a>(&'a self, _: u64, _: Interval, _: u64) -> Self::ModifiedChoices<'a>
         where
             Interval: 'a,

--- a/mapf/src/domain/activity.rs
+++ b/mapf/src/domain/activity.rs
@@ -29,17 +29,17 @@ use crate::{error::NoError, util::FlatResultMapTrait};
 /// that vertex.
 pub trait Activity<State> {
     /// What kind of action is produced by this activity
-    type ActivityAction;
+    type Action;
 
     /// What kind of error can happen if a bad state is provided
     type ActivityError;
 
     /// Concrete type for the returned container of choices
-    type Choices<'a>: IntoIterator<Item = Result<(Self::ActivityAction, State), Self::ActivityError>>
+    type Choices<'a>: IntoIterator<Item = Result<(Self::Action, State), Self::ActivityError>>
         + 'a
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         State: 'a;
 
@@ -48,7 +48,7 @@ pub trait Activity<State> {
     fn choices<'a>(&'a self, from_state: State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         State: 'a;
 }
@@ -57,20 +57,20 @@ pub trait Activity<State> {
 /// but it doesn't need to do anything.
 pub struct NoActivity<A>(std::marker::PhantomData<A>);
 impl<State, A> Activity<State> for NoActivity<A> {
-    type ActivityAction = A;
+    type Action = A;
     type ActivityError = NoError;
     type Choices<'a>
         = [Result<(A, State), NoError>; 0]
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         State: 'a;
 
     fn choices<'a>(&'a self, _: State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         State: 'a,
     {
@@ -139,30 +139,55 @@ where
     Prop: Activity<Base::State>,
     Prop::ActivityError: Into<Base::Error>,
 {
-    type ActivityAction = Prop::ActivityAction;
+    type Action = Prop::Action;
     type ActivityError = Base::Error;
-    type Choices<'a>
-        =
-        impl Iterator<Item = Result<(Self::ActivityAction, Base::State), Self::ActivityError>> + 'a
+    type Choices<'a> = IncorporatedChoices<'a, Base, Prop>
     where
         Self: 'a,
         Base: 'a,
         Prop: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a;
 
     fn choices<'a>(&'a self, from_state: Base::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a,
     {
-        self.prop
-            .choices(from_state)
-            .into_iter()
-            .map(|c| c.map(|(a, s)| (a.into(), s.into())).map_err(Into::into))
+        let choices = self.prop.choices(from_state).into_iter();
+        IncorporatedChoices { choices }
+    }
+}
+
+pub struct IncorporatedChoices<'a, Base, Prop>
+where
+    Base: Domain,
+    Base::State: 'a,
+    Prop: Activity<Base::State> + 'a,
+    Prop::Action: 'a,
+    Prop::ActivityError: Into<Base::Error> + 'a,
+{
+    choices: <Prop::Choices<'a> as IntoIterator>::IntoIter,
+}
+
+impl<'a, Base, Prop> Iterator for IncorporatedChoices<'a, Base, Prop>
+where
+    Base: Domain,
+    Prop: Activity<Base::State>,
+    Prop::ActivityError: Into<Base::Error>,
+{
+    type Item = Result<(Prop::Action, Base::State), Base::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(
+            self.choices
+            .next()?
+            .map(|(a, s)| (a.into(), s.into()))
+            .map_err(Into::into)
+        )
     }
 }
 
@@ -170,87 +195,163 @@ impl<Base, Prop> Activity<Base::State> for Chained<Base, Prop>
 where
     Base: Domain + Activity<Base::State>,
     Base::State: Clone,
-    Base::ActivityAction: Into<Prop::ActivityAction>,
     Base::ActivityError: Into<Base::Error>,
     Prop: Activity<Base::State>,
+    Prop::Action: Into<Base::Action>,
     Prop::ActivityError: Into<Base::Error>,
 {
-    type ActivityAction = Prop::ActivityAction;
+    type Action = Base::Action;
     type ActivityError = Base::Error;
-    type Choices<'a>
-        =
-        impl Iterator<Item = Result<(Self::ActivityAction, Base::State), Self::ActivityError>> + 'a
+    type Choices<'a> = ChainedChoices<'a, Base, Prop>
     where
         Self: 'a,
         Base: 'a,
         Prop: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a;
 
     fn choices<'a>(&'a self, from_state: Base::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a,
     {
-        self.base
-            .choices(from_state.clone())
-            .into_iter()
-            .map(|c| c.map(|(a, s)| (a.into(), s.into())).map_err(Into::into))
-            .chain(
-                self.prop
-                    .choices(from_state)
-                    .into_iter()
-                    .map(|c| c.map(|(a, s)| (a.into(), s.into())).map_err(Into::into)),
-            )
+        ChainedChoices {
+            base_choices: Some(self.base.choices(from_state.clone()).into_iter()),
+            prop_choices: self.prop.choices(from_state).into_iter(),
+        }
     }
 }
+
+pub struct ChainedChoices<'a, Base, Prop>
+where
+    Base: Domain + Activity<Base::State> + 'a,
+    Base::State: Clone,
+    Base::ActivityError: Into<Base::Error> + 'a,
+    Prop: Activity<Base::State> + 'a,
+    Prop::Action: Into<Base::Action>,
+    Prop::ActivityError: Into<Base::Error>,
+{
+    base_choices: Option<<Base::Choices<'a> as IntoIterator>::IntoIter>,
+    prop_choices: <Prop::Choices<'a> as IntoIterator>::IntoIter,
+}
+
+impl<'a, Base, Prop> Iterator for ChainedChoices<'a, Base, Prop>
+where
+    Base: Domain + Activity<Base::State>,
+    Base::State: Clone,
+    Base::ActivityError: Into<Base::Error>,
+    Prop: Activity<Base::State>,
+    Prop::Action: Into<Base::Action>,
+    Prop::ActivityError: Into<Base::Error>,
+{
+    type Item = Result<(Base::Action, Base::State), Base::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(base_choices) = &mut self.base_choices {
+                if let Some(next) = base_choices.next() {
+                    return Some(next.map_err(Into::into));
+                }
+            }
+            self.base_choices = None;
+
+            return self.prop_choices
+                .next()
+                .map(|r|
+                    r
+                    .map(|(a, s)| (a.into(), s.into()))
+                    .map_err(Into::into)
+                );
+        }
+    }
+}
+
 
 impl<Base, Prop> Activity<Base::State> for Mapped<Base, Prop>
 where
     Base: Domain + Activity<Base::State>,
     Base::State: Clone,
     Base::ActivityError: Into<Base::Error>,
-    Prop: ActivityModifier<Base::State, Base::ActivityAction>,
+    Prop: ActivityModifier<Base::State, Base::Action>,
     Prop::ModifiedActionError: Into<Base::Error>,
 {
-    type ActivityAction = Prop::ModifiedAction;
+    type Action = Prop::ModifiedAction;
     type ActivityError = Base::Error;
-    type Choices<'a>
-        =
-        impl Iterator<Item = Result<(Self::ActivityAction, Base::State), Self::ActivityError>> + 'a
+    type Choices<'a> = MappedChoices<'a, Base, Prop>
     where
         Self: 'a,
         Base: 'a,
         Prop: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a;
 
     fn choices<'a>(&'a self, from_state: Base::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a,
     {
-        self.base
-            .choices(from_state.clone())
-            .into_iter()
-            .flat_map(move |result| {
-                let from_state = from_state.clone();
-                result
-                    .map_err(Into::into)
-                    .flat_result_map(move |(action, to_state)| {
-                        self.prop
-                            .modify_action(from_state.clone(), action, to_state)
-                            .into_iter()
-                            .map(|r| r.map_err(Into::into).map(|(a, s)| (a, s.into())))
-                    })
-                    .map(|x| x.flatten())
-            })
+        let choices = self.base.choices(from_state.clone()).into_iter();
+        MappedChoices {
+            from_state,
+            choices,
+            modified_choices: None,
+            prop: &self.prop,
+        }
+    }
+}
+
+pub struct MappedChoices<'a, Base, Prop>
+where
+    Base: Domain + Activity<Base::State> + 'a,
+    Base::State: Clone,
+    Base::ActivityError: Into<Base::Error>,
+    Prop: ActivityModifier<Base::State, Base::Action> + 'a,
+    Prop::ModifiedActionError: Into<Base::Error>,
+{
+    from_state: Base::State,
+    choices: <Base::Choices<'a> as IntoIterator>::IntoIter,
+    modified_choices: Option<<Prop::ModifiedChoices<'a> as IntoIterator>::IntoIter>,
+    prop: &'a Prop,
+}
+
+impl<'a, Base, Prop> Iterator for MappedChoices<'a, Base, Prop>
+where
+    Base: Domain + Activity<Base::State>,
+    Base::State: Clone,
+    Base::ActivityError: Into<Base::Error>,
+    Prop: ActivityModifier<Base::State, Base::Action>,
+    Prop::ModifiedActionError: Into<Base::Error>,
+{
+    type Item = Result<(Prop::ModifiedAction, Base::State), Base::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(modified_choices) = &mut self.modified_choices {
+                if let Some(next_modified_action) = modified_choices.next() {
+                    let next = next_modified_action
+                        .map_err(Into::into);
+                    return Some(next);
+                }
+            }
+            self.modified_choices = None;
+
+            let (from_action, to_state): (Base::Action, Base::State) = match self.choices.next()? {
+                Ok(next) => next,
+                Err(err) => return Some(Err(err.into())),
+            };
+
+            self.modified_choices = Some(self.prop.modify_action(
+                self.from_state.clone(),
+                from_action,
+                to_state,
+            ).into_iter());
+        }
     }
 }
 
@@ -259,94 +360,141 @@ where
     Base: Domain,
     Lifter: ProjectState<Base::State>
         + LiftState<Base::State>
-        + ActionMap<Base::State, Prop::ActivityAction>,
+        + ActionMap<Base::State, Prop::Action>,
     Lifter::ActionMapError: Into<Base::Error>,
     Lifter::ProjectionError: Into<Base::Error>,
     Lifter::LiftError: Into<Base::Error>,
     Prop: Activity<Lifter::ProjectedState>,
     Base::State: Clone,
-    Prop::ActivityAction: Clone,
+    Prop::Action: Clone,
     Prop::ActivityError: Into<Base::Error>,
 {
-    type ActivityAction = Lifter::ToAction;
+    type Action = Lifter::ToAction;
     type ActivityError = Base::Error;
-    type Choices<'a>
-        =
-        impl Iterator<Item = Result<(Self::ActivityAction, Base::State), Self::ActivityError>> + 'a
+    type Choices<'a> = LiftedActivityChoices<'a, Base, Lifter, Prop>
     where
         Self: 'a,
         Base: 'a,
         Prop: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a;
 
     fn choices<'a>(&'a self, from_state: Base::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         Base::State: 'a,
     {
-        [self.lifter.project(&from_state)]
-            .into_iter()
-            .filter_map(
-                |r: Result<Option<Lifter::ProjectedState>, Lifter::ProjectionError>| r.transpose(),
-            )
-            .flat_map(
-                move |r: Result<Lifter::ProjectedState, Lifter::ProjectionError>| {
-                    let from_state = from_state.clone();
-                    r.map_err(Into::into)
-                        .flat_result_map(move |projected_state| {
-                            let from_state = from_state.clone();
-                            self.prop.choices(projected_state).into_iter().flat_map(
-                                move |r: Result<
-                                    (Prop::ActivityAction, Lifter::ProjectedState),
-                                    Prop::ActivityError,
-                                >| {
-                                    let from_state = from_state.clone();
-                                    r.map_err(Into::into)
-                                        .flat_result_map(move |(action, state)| {
-                                            let from_state = from_state.clone();
-                                            self.lifter
-                                                .lift(&from_state, state)
-                                                .map_err(Into::into)
-                                                .flat_result_map(
-                                                    move |lifted_state_opt: Option<Base::State>| {
-                                                        let from_state = from_state.clone();
-                                                        let action = action.clone();
-                                                        lifted_state_opt.into_iter().flat_map(
-                                                            move |lifted_state: Base::State| {
-                                                                let from_state = from_state.clone();
-                                                                let action = action.clone();
-                                                                self.lifter
-                                                                    .map_action(from_state, action)
-                                                                    .into_iter()
-                                                                    .map(move |r| {
-                                                                        let lifted_state =
-                                                                            lifted_state.clone();
-                                                                        r.map_err(Into::into).map(
-                                                                            move |a| {
-                                                                                (
-                                                                                    a.into(),
-                                                                                    lifted_state,
-                                                                                )
-                                                                            },
-                                                                        )
-                                                                    })
-                                                            },
-                                                        )
-                                                    },
-                                                )
-                                                .map(|x| x.flatten())
-                                        })
-                                        .map(|x| x.flatten())
-                                },
-                            )
-                        })
-                        .map(|x| x.flatten())
-                },
-            )
+        match self.lifter.project(&from_state) {
+            Ok(Some(projected_state)) => {
+                let choices = self.prop.choices(projected_state).into_iter();
+                return LiftedActivityChoices::Choices {
+                    from_state,
+                    choices,
+                    // lifted_actions will be filled in while iterating
+                    lifted_actions: None,
+                    lifter: &self.lifter,
+                }
+            }
+            Ok(None) => {
+                // This is not actually an error, but we can piggyback on the
+                // ProjectionError variant to have the desired effect for the
+                // iterator.
+                return LiftedActivityChoices::ProjectionError(None);
+            }
+            Err(err) => {
+                return LiftedActivityChoices::ProjectionError(Some(err));
+            }
+        }
+    }
+}
+
+pub enum LiftedActivityChoices<'a, Base, Lifter, Prop>
+where
+    Base: Domain,
+    Lifter: ProjectState<Base::State>
+        + LiftState<Base::State>
+        + ActionMap<Base::State, Prop::Action>,
+    Lifter::ActionMapError: Into<Base::Error> + 'a,
+    Lifter::ProjectionError: Into<Base::Error>,
+    Lifter::ProjectedState: 'a,
+    Lifter::LiftError: Into<Base::Error>,
+    Prop: Activity<Lifter::ProjectedState> + 'a,
+    Base::State: Clone + 'a,
+    Prop::Action: Clone + 'a,
+    Prop::ActivityError: Into<Base::Error> + 'a,
+{
+    ProjectionError(Option<Lifter::ProjectionError>),
+    Choices {
+        from_state: Base::State,
+        choices: <Prop::Choices<'a> as IntoIterator>::IntoIter,
+        lifted_actions: Option<(Base::State, <Lifter::ToActions<'a> as IntoIterator>::IntoIter)>,
+        lifter: &'a Lifter,
+    },
+}
+
+impl<'a, Base, Lifter, Prop> Iterator for LiftedActivityChoices<'a, Base, Lifter, Prop>
+where
+    Base: Domain,
+    Lifter: ProjectState<Base::State>
+        + LiftState<Base::State>
+        + ActionMap<Base::State, Prop::Action>,
+    Lifter::ActionMapError: Into<Base::Error>,
+    Lifter::ProjectionError: Into<Base::Error>,
+    Lifter::ProjectedState: 'a,
+    Lifter::LiftError: Into<Base::Error>,
+    Prop: Activity<Lifter::ProjectedState> + 'a,
+    Base::State: Clone + 'a,
+    Prop::Action: Clone + 'a,
+    Prop::ActivityError: Into<Base::Error> + 'a,
+    Lifter::ToAction: 'a,
+{
+    type Item = Result<(Lifter::ToAction, Base::State), Base::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (from_state, lifted_actions, choices, lifter) = match self {
+                Self::ProjectionError(error) => {
+                    return error.take().map(Into::into).map(Err);
+                }
+                Self::Choices { from_state, lifted_actions, choices, lifter } => {
+                    (from_state, lifted_actions, choices, lifter)
+                }
+            };
+
+            if let Some((state, lifted_actions)) = lifted_actions {
+                if let Some(next_lifted_action) = lifted_actions.next() {
+                    let next = next_lifted_action
+                        .map(|action| (action, state.clone()))
+                        .map_err(Into::into);
+                    return Some(next);
+                }
+            }
+            *lifted_actions = None;
+
+            let next: Result<(Prop::Action, Lifter::ProjectedState), Prop::ActivityError> = choices.next()?;
+
+            let (action, state) = match next {
+                Ok(ok) => ok,
+                Err(err) => return Some(Err(err.into())),
+            };
+
+            let lifted_state = match lifter.lift(&from_state, state).map_err(Into::into) {
+                Ok(lifted_state) => lifted_state,
+                Err(err) => return Some(Err(err.into()))
+            };
+
+            let Some(lifted_state) = lifted_state else {
+                continue;
+            };
+
+            *lifted_actions = Some((
+                lifted_state,
+                lifter.map_action(from_state.clone(), action).into_iter(),
+            ));
+        }
     }
 }
 
@@ -365,14 +513,14 @@ mod tests {
     struct Interval(u64);
 
     impl Activity<u64> for Count {
-        type ActivityAction = Interval;
+        type Action = Interval;
         type ActivityError = NoError;
         type Choices<'a> = impl Iterator<Item = Result<(Interval, u64), NoError>> + 'a;
 
         fn choices<'a>(&'a self, s: u64) -> Self::Choices<'a>
         where
             Self: 'a,
-            Self::ActivityAction: 'a,
+            Self::Action: 'a,
             Self::ActivityError: 'a,
             u64: 'a,
         {
@@ -552,7 +700,7 @@ mod tests {
     #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
     struct Buy(u64 /* price per unit */);
     impl Activity<Item> for Buy {
-        type ActivityAction = Buy;
+        type Action = Buy;
         type ActivityError = NoError;
         type Choices<'a> = Option<Result<(Buy, Item), NoError>>;
         fn choices<'a>(&'a self, mut from_state: Item) -> Option<Result<(Buy, Item), NoError>>
@@ -571,7 +719,7 @@ mod tests {
     #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
     struct Sell(u64 /* price per unit */);
     impl Activity<Item> for Sell {
-        type ActivityAction = Sell;
+        type Action = Sell;
         type ActivityError = NoError;
         type Choices<'a> = Option<Result<(Sell, Item), NoError>>;
         fn choices<'a>(&'a self, mut from_state: Item) -> Self::Choices<'a>

--- a/mapf/src/domain/closable/keyed_closed_set.rs
+++ b/mapf/src/domain/closable/keyed_closed_set.rs
@@ -120,22 +120,6 @@ where
         let key = self.keyring.key_for(state);
         self.container.get(key.borrow()).into()
     }
-
-    type ClosedSetIter<'a>
-        = impl Iterator<Item = &'a T> + 'a
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> Self::ClosedSetIter<'a>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a,
-    {
-        self.container.values()
-    }
 }
 
 impl<Ring: Keyed, T> ClosedStatusForKey<Ring::Key, T> for KeyedClosedSet<Ring, T> {

--- a/mapf/src/domain/closable/mod.rs
+++ b/mapf/src/domain/closable/mod.rs
@@ -108,18 +108,6 @@ pub trait ClosedSet<State, T> {
 
     /// Get the status of the specified state.
     fn status<'a>(&'a self, state: &State) -> ClosedStatus<'a, T>;
-
-    type ClosedSetIter<'a>: IntoIterator<Item = &'a T> + 'a
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> Self::ClosedSetIter<'a>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
 }
 
 /// This trait can supplement [`ClosedSet`] by allowing the closed items to be

--- a/mapf/src/domain/closable/partial_keyed_closed_set.rs
+++ b/mapf/src/domain/closable/partial_keyed_closed_set.rs
@@ -141,8 +141,7 @@ where
         self.container.get(key).into()
     }
 
-    type ClosedSetIter<'a>
-        = impl Iterator<Item = &'a T> + 'a
+    type ClosedSetIter<'a> = std::collections::hash_map::Values<'a, Ring::PartialKey, T>
     where
         Self: 'a,
         State: 'a,

--- a/mapf/src/domain/closable/partial_keyed_closed_set.rs
+++ b/mapf/src/domain/closable/partial_keyed_closed_set.rs
@@ -140,21 +140,6 @@ where
         };
         self.container.get(key).into()
     }
-
-    type ClosedSetIter<'a> = std::collections::hash_map::Values<'a, Ring::PartialKey, T>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> Self::ClosedSetIter<'a>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a,
-    {
-        self.container.values()
-    }
 }
 
 impl<Ring, T> ClosedStatusForKey<Option<Ring::PartialKey>, T> for PartialKeyedClosedSet<Ring, T>

--- a/mapf/src/domain/closable/time_variant_keyed_closed_set.rs
+++ b/mapf/src/domain/closable/time_variant_keyed_closed_set.rs
@@ -171,22 +171,6 @@ where
             .flatten()
             .into()
     }
-
-    type ClosedSetIter<'a>
-        = impl Iterator<Item = &'a T> + 'a
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> Self::ClosedSetIter<'a>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a,
-    {
-        self.container.values().flat_map(|c| c.values())
-    }
 }
 
 impl<Ring: Keyed, T> ClosedStatusForKey<Ring::Key, T> for TimeVariantKeyedClosedSet<Ring, T> {

--- a/mapf/src/domain/closable/time_variant_partial_keyed_closed_set.rs
+++ b/mapf/src/domain/closable/time_variant_partial_keyed_closed_set.rs
@@ -180,22 +180,6 @@ where
             .flatten()
             .into()
     }
-
-    type ClosedSetIter<'a>
-        = impl Iterator<Item = &'a T> + 'a
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> Self::ClosedSetIter<'a>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a,
-    {
-        self.container.values().flat_map(|c| c.values())
-    }
 }
 
 impl<Ring, T> ClosedStatusForKey<Option<Ring::PartialKey>, T>

--- a/mapf/src/domain/connectable.rs
+++ b/mapf/src/domain/connectable.rs
@@ -75,7 +75,8 @@ where
     State: Clone,
 {
     type ConnectionError = Prop::ConnectionError;
-    type Connections<'a> = ChainedConnections<'a, Base, Prop, State, Action, Target>
+    type Connections<'a>
+        = ChainedConnections<'a, Base, Prop, State, Action, Target>
     where
         Self: 'a,
         Self::ConnectionError: 'a,
@@ -111,7 +112,8 @@ where
     prop_connections: <Prop::Connections<'a> as IntoIterator>::IntoIter,
 }
 
-impl<'a, Base, Prop, State, Action, Target> Iterator for ChainedConnections<'a, Base, Prop, State, Action, Target>
+impl<'a, Base, Prop, State, Action, Target> Iterator
+    for ChainedConnections<'a, Base, Prop, State, Action, Target>
 where
     Base: Connectable<State, Action, Target> + 'a,
     Prop: Connectable<State, Action, Target> + 'a,

--- a/mapf/src/domain/define_trait.rs
+++ b/mapf/src/domain/define_trait.rs
@@ -176,7 +176,7 @@ impl<Base: Domain, Lifter, Prop> Domain for Lifted<Base, Lifter, Prop> {
 }
 
 pub trait Lift {
-    /// Lifts from the domain of property into the base domain using Lifter.
+    /// Lifts from the domain of `Prop` into the base domain using Lifter.
     ///
     /// This can be used to incorporate subspace behaviors or projected domains
     /// into your domain.

--- a/mapf/src/domain/initializable.rs
+++ b/mapf/src/domain/initializable.rs
@@ -114,7 +114,8 @@ where
     Goal: Clone,
 {
     type InitialError = Init::InitialError;
-    type InitialStates<'a> = ManyInitIter<'a, StartIter, Goal, State, Init>
+    type InitialStates<'a>
+        = ManyInitIter<'a, StartIter, Goal, State, Init>
     where
         Self: 'a,
         Self::InitialError: 'a,
@@ -189,7 +190,8 @@ where
     Init: Initializable<Start, Goal, Init::State>,
 {
     type InitialError = Init::InitialError;
-    type InitialStates<'a> = LiftInitIter<
+    type InitialStates<'a>
+        = LiftInitIter<
         <Init::InitialStates<'a> as IntoIterator>::IntoIter,
         Init::State,
         State,
@@ -224,14 +226,12 @@ pub struct LiftInitIter<InitIter, IterState, State, Error> {
 
 impl<InitIter, IterState, State, Error> Iterator for LiftInitIter<InitIter, IterState, State, Error>
 where
-    InitIter: Iterator<Item=Result<IterState, Error>>,
+    InitIter: Iterator<Item = Result<IterState, Error>>,
     IterState: Into<State>,
 {
     type Item = Result<State, Error>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|r| r.map(Into::into))
+        self.iter.next().map(|r| r.map(Into::into))
     }
 }
 
@@ -242,7 +242,8 @@ where
     Prop::InitialError: Into<Base::Error>,
 {
     type InitialError = Base::Error;
-    type InitialStates<'a> = IntoInitialStatesIter<'a, Base, Prop, Start, Goal>
+    type InitialStates<'a>
+        = IntoInitialStatesIter<'a, Base, Prop, Start, Goal>
     where
         Self: 'a,
         Base::Error: 'a,
@@ -259,7 +260,7 @@ where
         Goal: 'a,
     {
         IntoInitialStatesIter {
-            iter: self.prop.initialize(from_start, to_goal).into_iter()
+            iter: self.prop.initialize(from_start, to_goal).into_iter(),
         }
     }
 }
@@ -285,9 +286,7 @@ where
 {
     type Item = Result<Base::State, Base::Error>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|r| r.map_err(Into::into))
+        self.iter.next().map(|r| r.map_err(Into::into))
     }
 }
 

--- a/mapf/src/domain/initializable.rs
+++ b/mapf/src/domain/initializable.rs
@@ -114,8 +114,7 @@ where
     Goal: Clone,
 {
     type InitialError = Init::InitialError;
-    type InitialStates<'a>
-        = impl Iterator<Item = Result<State, Self::InitialError>> + 'a
+    type InitialStates<'a> = ManyInitIter<'a, StartIter, Goal, State, Init>
     where
         Self: 'a,
         Self::InitialError: 'a,
@@ -128,13 +127,56 @@ where
         Self: 'a,
         Self::InitialError: 'a,
         StartIter: 'a,
-        Goal: 'a,
+        Goal: 'a + Clone,
         State: 'a,
     {
-        let to_goal = to_goal.clone();
-        from_start
-            .into_iter()
-            .flat_map(move |start| self.0.initialize(start, &to_goal))
+        ManyInitIter {
+            current_iter: None,
+            remaining_iters: from_start.into_iter(),
+            init: &self.0,
+            goal: to_goal.clone(),
+        }
+    }
+}
+
+pub struct ManyInitIter<'a, StartIter, Goal, State, Init>
+where
+    StartIter: 'a + IntoIterator,
+    Init: 'a + Initializable<StartIter::Item, Goal, State>,
+    Goal: 'a,
+    State: 'a,
+    Init::InitialError: 'a,
+{
+    current_iter: Option<<Init::InitialStates<'a> as IntoIterator>::IntoIter>,
+    remaining_iters: StartIter::IntoIter,
+    init: &'a Init,
+    goal: Goal,
+}
+
+impl<'a, StartIter, Goal, State, Init> Iterator for ManyInitIter<'a, StartIter, Goal, State, Init>
+where
+    StartIter: 'a + IntoIterator,
+    Init: 'a + Initializable<StartIter::Item, Goal, State>,
+    Goal: 'a + Clone,
+    State: 'a,
+    Init::InitialError: 'a,
+{
+    type Item = Result<State, Init::InitialError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(iter) = &mut self.current_iter {
+                if let Some(next) = iter.next() {
+                    return Some(next);
+                }
+            }
+            self.current_iter = None;
+
+            if let Some(next_start) = self.remaining_iters.next() {
+                self.current_iter = Some(self.init.initialize(next_start, &self.goal).into_iter());
+            } else {
+                return None;
+            }
+        }
     }
 }
 
@@ -144,11 +186,15 @@ impl<Start, Goal, State, Init> Initializable<Start, Goal, State> for LiftInit<In
 where
     Init: Domain,
     Init::State: Into<State>,
-    Init: Initializable<Start, Goal, State>,
+    Init: Initializable<Start, Goal, Init::State>,
 {
     type InitialError = Init::InitialError;
-    type InitialStates<'a>
-        = impl Iterator<Item = Result<State, Self::InitialError>> + 'a
+    type InitialStates<'a> = LiftInitIter<
+        <Init::InitialStates<'a> as IntoIterator>::IntoIter,
+        Init::State,
+        State,
+        Init::InitialError,
+    >
     where
         Self: 'a,
         Self::InitialError: 'a,
@@ -164,10 +210,28 @@ where
         Goal: 'a,
         State: 'a,
     {
-        self.0
-            .initialize(from_start, to_goal)
-            .into_iter()
-            .map(|s| s.into())
+        LiftInitIter::<_, Init::State, State, Init::InitialError> {
+            iter: self.0.initialize(from_start, to_goal).into_iter(),
+            _ignore: Default::default(),
+        }
+    }
+}
+
+pub struct LiftInitIter<InitIter, IterState, State, Error> {
+    iter: InitIter,
+    _ignore: std::marker::PhantomData<fn(IterState, State, Error)>,
+}
+
+impl<InitIter, IterState, State, Error> Iterator for LiftInitIter<InitIter, IterState, State, Error>
+where
+    InitIter: Iterator<Item=Result<IterState, Error>>,
+    IterState: Into<State>,
+{
+    type Item = Result<State, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|r| r.map(Into::into))
     }
 }
 
@@ -178,8 +242,7 @@ where
     Prop::InitialError: Into<Base::Error>,
 {
     type InitialError = Base::Error;
-    type InitialStates<'a>
-        = impl Iterator<Item = Result<Base::State, Base::Error>> + 'a
+    type InitialStates<'a> = IntoInitialStatesIter<'a, Base, Prop, Start, Goal>
     where
         Self: 'a,
         Base::Error: 'a,
@@ -195,10 +258,36 @@ where
         Start: 'a,
         Goal: 'a,
     {
-        self.prop
-            .initialize(from_start, to_goal)
-            .into_iter()
-            .map(|r| r.map(Into::into).map_err(Into::into))
+        IntoInitialStatesIter {
+            iter: self.prop.initialize(from_start, to_goal).into_iter()
+        }
+    }
+}
+
+pub struct IntoInitialStatesIter<'a, Base, Prop, Start, Goal>
+where
+    Base: 'a + Domain,
+    Prop: 'a + Initializable<Start, Goal, Base::State>,
+    Prop::InitialError: 'a + Into<Base::Error>,
+    Start: 'a,
+    Goal: 'a,
+{
+    iter: <Prop::InitialStates<'a> as IntoIterator>::IntoIter,
+}
+
+impl<'a, Base, Prop, Start, Goal> Iterator for IntoInitialStatesIter<'a, Base, Prop, Start, Goal>
+where
+    Base: 'a + Domain,
+    Prop: 'a + Initializable<Start, Goal, Base::State>,
+    Prop::InitialError: 'a + Into<Base::Error>,
+    Start: 'a,
+    Goal: 'a,
+{
+    type Item = Result<Base::State, Base::Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|r| r.map_err(Into::into))
     }
 }
 

--- a/mapf/src/graph/mod.rs
+++ b/mapf/src/graph/mod.rs
@@ -93,7 +93,7 @@ pub trait Graph {
         Self::EdgeAttributes: 'a;
 
     /// Get the "lazy" edges that exist between from_key and to_key. Lazy Graphs
-    /// ("lazy" in the sense of lazy evaluation) can cover more space with less
+    /// ("lazy" in the sense of "lazy evaluation") can cover more space with less
     /// branching by not returning all possible edges in the `edges_from_vertex`
     /// function and instead only returning edges that lead to critical vertices.
     /// Then those critical vertices can be supplemented with this

--- a/mapf/src/graph/occupancy/accessibility_graph.rs
+++ b/mapf/src/graph/occupancy/accessibility_graph.rs
@@ -63,7 +63,8 @@ impl<G: Grid> Graph for AccessibilityGraph<G> {
         = (Cell, Cell)
     where
         G: 'a;
-    type EdgeIter<'a> = AccessibilityGraphEdges
+    type EdgeIter<'a>
+        = AccessibilityGraphEdges
     where
         Self: 'a;
 
@@ -96,7 +97,10 @@ impl<G: Grid> Graph for AccessibilityGraph<G> {
 
         let from_cell = *key;
         let directions = directions.into_iter();
-        AccessibilityGraphEdges::Edges { from_cell, directions }
+        AccessibilityGraphEdges::Edges {
+            from_cell,
+            directions,
+        }
     }
 
     type LazyEdgeIter<'a>
@@ -126,7 +130,11 @@ pub enum AccessibilityGraphEdges {
 impl Iterator for AccessibilityGraphEdges {
     type Item = (Cell, Cell);
     fn next(&mut self) -> Option<Self::Item> {
-        let Self::Edges { from_cell, directions } = self else {
+        let Self::Edges {
+            from_cell,
+            directions,
+        } = self
+        else {
             return None;
         };
 

--- a/mapf/src/graph/occupancy/accessibility_graph.rs
+++ b/mapf/src/graph/occupancy/accessibility_graph.rs
@@ -23,7 +23,6 @@ use crate::{
         Graph,
     },
     motion::r2::Point,
-    util::ForkIter,
 };
 use bitfield::{bitfield, Bit};
 use std::{

--- a/mapf/src/graph/occupancy/mod.rs
+++ b/mapf/src/graph/occupancy/mod.rs
@@ -21,8 +21,11 @@ use crate::{
 };
 use bitfield::{bitfield, Bit, BitMut};
 use std::{
+    collections::{
+        hash_map::{Entry, Iter as HashMapIter},
+        HashMap, HashSet,
+    },
     ops::Sub,
-    collections::{hash_map::{Entry, Iter as HashMapIter}, HashMap, HashSet}
 };
 use util::LineSegment;
 
@@ -394,12 +397,8 @@ impl<G: Grid> Visibility<G> {
 
     pub fn calculate_visibility(&self, cell: Cell) -> VisibleCells<'_, G> {
         let visibility_edges = match self.edges.get(&cell) {
-            Some(visibility_edges) => {
-                VisibilityEdges::Precalculated(visibility_edges.into_iter())
-            }
-            None => {
-                VisibilityEdges::Unknown(self.iter_points())
-            }
+            Some(visibility_edges) => VisibilityEdges::Precalculated(visibility_edges.into_iter()),
+            None => VisibilityEdges::Unknown(self.iter_points()),
         };
 
         VisibleCells {
@@ -419,9 +418,7 @@ impl<G: Grid> Visibility<G> {
                 // direction.
                 None
             }
-            None => {
-                Some(secondary_cardinal_directions().into_iter())
-            }
+            None => Some(secondary_cardinal_directions().into_iter()),
         };
 
         NeighborsIter {
@@ -739,7 +736,11 @@ impl<'a, G: Grid> Iterator for VisibleCells<'a, G> {
                         let cell_size = self.grid.cell_size();
                         let p0 = self.from_cell.center_point(cell_size);
                         let p1 = to_cell.center_point(cell_size);
-                        if self.grid.is_sweep_occupied(p0, p1, 2.0 * self.agent_radius).is_some() {
+                        if self
+                            .grid
+                            .is_sweep_occupied(p0, p1, 2.0 * self.agent_radius)
+                            .is_some()
+                        {
                             continue;
                         }
 
@@ -772,7 +773,7 @@ impl<'a> Iterator for VisiblePointsIter<'a> {
                     continue;
                 }
 
-                return Some((cell, status))
+                return Some((cell, status));
             } else {
                 return None;
             }
@@ -798,7 +799,9 @@ impl<'a, G: Grid> Iterator for NeighborsIter<'a, G> {
         loop {
             if let Some([i, j]) = directions.next() {
                 let neighbor = self.of_cell.shifted(i, j);
-                if self.grid.is_sweep_occupied(
+                if self
+                    .grid
+                    .is_sweep_occupied(
                         self.from_point,
                         neighbor.center_point(self.grid.cell_size()),
                         self.agent_diameter,

--- a/mapf/src/graph/occupancy/mod.rs
+++ b/mapf/src/graph/occupancy/mod.rs
@@ -20,8 +20,10 @@ use crate::{
     util::triangular_for,
 };
 use bitfield::{bitfield, Bit, BitMut};
-use std::collections::{hash_map, HashMap, HashSet};
-use std::ops::Sub;
+use std::{
+    ops::Sub,
+    collections::{hash_map::{Entry, Iter as HashMapIter}, HashMap, HashSet}
+};
 use util::LineSegment;
 
 pub type Point = nalgebra::geometry::Point2<f64>;
@@ -367,11 +369,10 @@ impl<G: Grid> Visibility<G> {
         );
     }
 
-    pub fn iter_points(&self) -> impl Iterator<Item = (&Cell, &CornerStatus)> {
-        self.points
-            .iter()
-            .filter(|(_, (blocked_by, _))| blocked_by.is_none())
-            .map(|(cell, (_, corner_status))| (cell, corner_status))
+    pub fn iter_points(&self) -> VisiblePointsIter<'_> {
+        VisiblePointsIter {
+            iter: self.points.iter(),
+        }
     }
 
     pub fn debug_points(&self) -> &HashMap<Cell, (BlockedBy, CornerStatus)> {
@@ -391,78 +392,45 @@ impl<G: Grid> Visibility<G> {
         return &self.edges;
     }
 
-    pub fn calculate_visibility(&self, cell: Cell) -> impl Iterator<Item = Cell> + '_ {
-        let visibility_edges = self.edges.get(&cell);
-        [visibility_edges]
-            .into_iter()
-            .filter_map(|x| x)
-            .flat_map(|edges| {
-                edges
-                    .into_iter()
-                    .filter(|(_, blocked_by)| blocked_by.is_none())
-                    .map(|(cell, _)| *cell)
-            })
-            .chain(
-                // This chain kicks in when visibility_edges returned None, which
-                // means we need to calculate the visibility for this cell.
-                [visibility_edges]
-                    .into_iter()
-                    .filter(|x| x.is_none())
-                    .flat_map(move |_| {
-                        self.iter_points()
-                            .filter(move |(v_cell, corner_status)| {
-                                if !cell.in_visible_quadrant_of(*v_cell, **corner_status) {
-                                    return false;
-                                }
+    pub fn calculate_visibility(&self, cell: Cell) -> VisibleCells<'_, G> {
+        let visibility_edges = match self.edges.get(&cell) {
+            Some(visibility_edges) => {
+                VisibilityEdges::Precalculated(visibility_edges.into_iter())
+            }
+            None => {
+                VisibilityEdges::Unknown(self.iter_points())
+            }
+        };
 
-                                let cell_size = self.grid.cell_size();
-                                let p0 = cell.center_point(cell_size);
-                                let p1 = v_cell.center_point(cell_size);
-                                return self
-                                    .grid
-                                    .is_sweep_occupied(p0, p1, 2.0 * self.agent_radius)
-                                    .is_none();
-                            })
-                            .map(|(v_cell, _)| *v_cell)
-                    }),
-            )
+        VisibleCells {
+            grid: &self.grid,
+            agent_radius: self.agent_radius,
+            visibility_edges,
+            from_cell: cell,
+        }
     }
 
-    pub fn neighbors(&self, of_cell: Cell) -> impl Iterator<Item = Cell> + '_ {
-        [of_cell]
-            .into_iter()
-            .filter(|of_cell| {
-                self.grid()
-                    .is_square_occupied(
-                        of_cell.center_point(self.grid().cell_size()),
-                        2.0 * self.agent_radius,
-                    )
-                    .is_none()
-            })
-            .flat_map(move |of_cell| {
-                [-1, 0, 1].into_iter().flat_map(move |i| {
-                    [-1, 0, 1]
-                        .into_iter()
-                        .filter(move |j| !(i == 0 && *j == 0))
-                        .filter_map(move |j| {
-                            let cell_size = self.grid().cell_size();
-                            let neighbor = of_cell.shifted(i, j);
-                            if self
-                                .grid()
-                                .is_sweep_occupied(
-                                    of_cell.center_point(cell_size),
-                                    neighbor.center_point(cell_size),
-                                    2.0 * self.agent_radius(),
-                                )
-                                .is_none()
-                            {
-                                Some(neighbor)
-                            } else {
-                                None
-                            }
-                        })
-                })
-            })
+    pub fn neighbors(&self, of_cell: Cell) -> NeighborsIter<'_, G> {
+        let from_point = of_cell.center_point(self.grid.cell_size());
+        let agent_diameter = 2.0 * self.agent_radius;
+        let directions = match self.grid.is_square_occupied(from_point, agent_diameter) {
+            Some(_) => {
+                // The initial cell is blocked, so we can't actually go in any
+                // direction.
+                None
+            }
+            None => {
+                Some(secondary_cardinal_directions().into_iter())
+            }
+        };
+
+        NeighborsIter {
+            grid: &self.grid,
+            agent_diameter,
+            of_cell,
+            from_point,
+            directions,
+        }
     }
 
     /// Get a reference to the underlying occupancy grid.
@@ -520,7 +488,7 @@ impl<G: Grid> Visibility<G> {
 
                 if valid {
                     match points.entry(cell) {
-                        hash_map::Entry::Vacant(entry) => {
+                        Entry::Vacant(entry) => {
                             // If this corner point is currently vacant, then we
                             // need to check whether it has any blockers.
                             let blocked_by = grid.is_square_occupied(
@@ -534,7 +502,7 @@ impl<G: Grid> Visibility<G> {
                                 .set(corner, true);
                             new_points.push(cell);
                         }
-                        hash_map::Entry::Occupied(mut entry) => {
+                        Entry::Occupied(mut entry) => {
                             entry.get_mut().1.set(corner, true);
                             let mut remove_connections = Vec::new();
                             for (other, _) in edges.entry(cell).or_default() {
@@ -551,10 +519,10 @@ impl<G: Grid> Visibility<G> {
                     }
                 } else {
                     match points.entry(cell) {
-                        hash_map::Entry::Vacant(_) => {
+                        Entry::Vacant(_) => {
                             // Nothing needs to be done
                         }
-                        hash_map::Entry::Occupied(mut entry) => {
+                        Entry::Occupied(mut entry) => {
                             entry.get_mut().1.set(corner, false);
                             if !entry.get().1.is_corner() {
                                 // This entry is no longer a corner, so we need
@@ -637,7 +605,7 @@ impl<G: Grid> Visibility<G> {
                     }
 
                     let connection_entry = cell_connections.entry(*other);
-                    if let hash_map::Entry::Occupied(_) = connection_entry {
+                    if let Entry::Occupied(_) = connection_entry {
                         // If this connection is already active then we don't need
                         // to do anything here.
                         continue;
@@ -660,10 +628,10 @@ impl<G: Grid> Visibility<G> {
                     // When .insert_entry becomes stable we can change this match block to
                     // connection_entry.insert_entry(blocked_by);
                     match connection_entry {
-                        hash_map::Entry::Occupied(mut entry) => {
+                        Entry::Occupied(mut entry) => {
                             entry.insert(blocked_by);
                         }
-                        hash_map::Entry::Vacant(entry) => {
+                        Entry::Vacant(entry) => {
                             entry.insert(blocked_by);
                         }
                     }
@@ -689,7 +657,7 @@ impl<G: Grid> Visibility<G> {
         triangular_for(points.iter(), |(cell_i, _), (cell_j, _)| {
             for (changed_cell, occupied) in confirmed_changes {
                 let mut changed_blocker: Option<Option<Cell>> = None;
-                if let hash_map::Entry::Occupied(entry) =
+                if let Entry::Occupied(entry) =
                     &mut edges.entry(**cell_i).or_default().entry(*cell_j)
                 {
                     if *occupied {
@@ -738,6 +706,117 @@ impl<G: Grid> Visibility<G> {
     }
 }
 
+pub struct VisibleCells<'a, G: Grid> {
+    grid: &'a G,
+    agent_radius: f64,
+    visibility_edges: VisibilityEdges<'a>,
+    from_cell: Cell,
+}
+
+impl<'a, G: Grid> Iterator for VisibleCells<'a, G> {
+    type Item = Cell;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match &mut self.visibility_edges {
+                VisibilityEdges::Precalculated(visibility_edges) => {
+                    if let Some((cell, blocked_by)) = visibility_edges.next() {
+                        if blocked_by.is_some() {
+                            // Skip this cell because it is blocked
+                            continue;
+                        }
+
+                        return Some(*cell);
+                    }
+                }
+                VisibilityEdges::Unknown(visible_points) => {
+                    if let Some((to_cell, status)) = visible_points.next() {
+                        if !self.from_cell.in_visible_quadrant_of(to_cell, *status) {
+                            // Skip this cell because it's not visible from the
+                            // initial cell.
+                            continue;
+                        }
+
+                        let cell_size = self.grid.cell_size();
+                        let p0 = self.from_cell.center_point(cell_size);
+                        let p1 = to_cell.center_point(cell_size);
+                        if self.grid.is_sweep_occupied(p0, p1, 2.0 * self.agent_radius).is_some() {
+                            continue;
+                        }
+
+                        return Some(*to_cell);
+                    }
+                }
+            }
+
+            return None;
+        }
+    }
+}
+
+enum VisibilityEdges<'a> {
+    Precalculated(HashMapIter<'a, Cell, Option<Cell>>),
+    Unknown(VisiblePointsIter<'a>),
+}
+
+pub struct VisiblePointsIter<'a> {
+    iter: HashMapIter<'a, Cell, (BlockedBy, CornerStatus)>,
+}
+
+impl<'a> Iterator for VisiblePointsIter<'a> {
+    type Item = (&'a Cell, &'a CornerStatus);
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some((cell, (blocked_by, status))) = self.iter.next() {
+                if blocked_by.is_some() {
+                    // Skip this point because it is currently blocked
+                    continue;
+                }
+
+                return Some((cell, status))
+            } else {
+                return None;
+            }
+        }
+    }
+}
+
+pub struct NeighborsIter<'a, G> {
+    grid: &'a G,
+    agent_diameter: f64,
+    of_cell: Cell,
+    from_point: Point,
+    directions: Option<std::array::IntoIter<[i64; 2], 8>>,
+}
+
+impl<'a, G: Grid> Iterator for NeighborsIter<'a, G> {
+    type Item = Cell;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(directions) = self.directions.as_mut() else {
+            return None;
+        };
+
+        loop {
+            if let Some([i, j]) = directions.next() {
+                let neighbor = self.of_cell.shifted(i, j);
+                if self.grid.is_sweep_occupied(
+                        self.from_point,
+                        neighbor.center_point(self.grid.cell_size()),
+                        self.agent_diameter,
+                    )
+                    .is_some()
+                {
+                    // Skip this point since it's blocked
+                    continue;
+                }
+
+                return Some(neighbor);
+            }
+
+            return None;
+        }
+    }
+}
+
 pub struct UnstableVisibilityAPI<'a, G: Grid> {
     parent: &'a Visibility<G>,
 }
@@ -779,8 +858,8 @@ impl UniqueCellPairSet {
 
 pub struct VisibilityEdgeIter<'a, G: Grid> {
     visibility: &'a Visibility<G>,
-    point_iter: hash_map::Iter<'a, Cell, HashMap<Cell, BlockedBy>>,
-    edge_iter: Option<(&'a Cell, hash_map::Iter<'a, Cell, BlockedBy>)>,
+    point_iter: HashMapIter<'a, Cell, HashMap<Cell, BlockedBy>>,
+    edge_iter: Option<(&'a Cell, HashMapIter<'a, Cell, BlockedBy>)>,
     pair_tracker: UniqueCellPairSet,
 }
 
@@ -832,6 +911,19 @@ impl<'a, G: Grid> Iterator for VisibilityEdgeIter<'a, G> {
 
         return None;
     }
+}
+
+pub fn secondary_cardinal_directions() -> [[i64; 2]; 8] {
+    [
+        [-1, -1],
+        [-1, 0],
+        [-1, 1],
+        [0, -1],
+        [0, 1],
+        [1, -1],
+        [1, 0],
+        [1, 1],
+    ]
 }
 
 pub mod sparse_grid;

--- a/mapf/src/graph/occupancy/visibility_graph.rs
+++ b/mapf/src/graph/occupancy/visibility_graph.rs
@@ -19,13 +19,13 @@ use crate::{
     domain::Reversible,
     error::NoError,
     graph::{
-        occupancy::{Cell, Grid, Point, Visibility},
+        occupancy::{Cell, Grid, Point, Visibility, VisibleCells, NeighborsIter},
         Edge, Graph,
     },
     util::triangular_for,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_set::Iter as HashSetIter},
     sync::Arc,
 };
 
@@ -311,8 +311,7 @@ impl<G: Grid> Graph for NeighborhoodGraph<G> {
         = (Cell, Cell)
     where
         G: 'a;
-    type EdgeIter<'a>
-        = impl Iterator<Item = (Cell, Cell)> + 'a
+    type EdgeIter<'a> = NeighborhoodGraphEdges<'a, G>
     where
         Self: 'a;
 
@@ -330,69 +329,102 @@ impl<G: Grid> Graph for NeighborhoodGraph<G> {
     {
         // dbg!("neighborhood graph");
         let from_cell = *from_cell;
-        let from_p = from_cell.center_point(self.visibility.grid().cell_size());
-        [from_cell]
-            .into_iter()
-            .filter(move |_| {
-                // dbg!(from_cell);
-                self.visibility
-                    .grid()
-                    .is_square_occupied(from_p, 2.0 * self.visibility.agent_radius())
-                    .is_none()
-            })
-            .flat_map(move |_| {
-                // dbg!(from_cell);
-                self.visibility
-                    .calculate_visibility(from_cell)
-                    .filter(move |to_cell| {
-                        // dbg!(to_cell);
-                        // Ignore adjacent cells because those will be given by the
-                        // neighbors iterator below. If we repeat the same cell twice,
-                        // we force the search queue to do unnecessary work.
-                        (to_cell.x - from_cell.x).abs() > 1 || (to_cell.y - from_cell.y).abs() > 1
-                    })
-                    .map(move |to_cell| (from_cell, to_cell))
-                    .chain(
-                        self.visibility
-                            .neighbors(from_cell)
-                            .map(move |to_cell| (from_cell, to_cell))
-                            .filter(|(from_cell, to_cell)| {
-                                // dbg!((from_cell, to_cell));
-                                // dbg!(from_cell != to_cell)
-                                from_cell != to_cell
-                            }),
-                    )
-                    .chain({
-                        let interest = self.visibility_of_interest.get(&from_cell);
-                        interest
-                            .into_iter()
-                            .flat_map(|x| x)
-                            .map(move |point_of_interest| (from_cell, *point_of_interest))
-                            .chain([interest].into_iter().filter(|x| x.is_none()).flat_map(
-                                move |_| {
-                                    self.points_of_interest
-                                        .iter()
-                                        .filter(move |poi| {
-                                            let to_p = poi
-                                                .center_point(self.visibility.grid().cell_size());
-                                            self.visibility
-                                                .grid()
-                                                .is_sweep_occupied(
-                                                    from_p,
-                                                    to_p,
-                                                    2.0 * self.visibility.agent_radius(),
-                                                )
-                                                .is_none()
-                                        })
-                                        .map(move |poi| (from_cell.clone(), *poi))
-                                },
-                            ))
-                    })
-            })
+        let from_point = from_cell.center_point(self.visibility.grid().cell_size());
+        let agent_diameter = 2.0 * self.visibility.agent_radius;
+
+        let neighborhood = match self.visibility.grid.is_square_occupied(from_point,  agent_diameter) {
+            Some(_) => {
+                // The initial cell is blocked, so it is cut off from its neighborhood
+                None
+            }
+            None => {
+                let (visibility_of_interest, points_of_interest) = match self.visibility_of_interest.get(&from_cell) {
+                    Some(visibility_of_interest) => {
+                        (Some(visibility_of_interest.iter()), None)
+                    }
+                    None => {
+                        (None, Some(self.points_of_interest.iter()))
+                    }
+                };
+
+                Some(NeighborhoodGraphEdgesIters {
+                    visible_cells: self.visibility.calculate_visibility(from_cell),
+                    neighbors: self.visibility.neighbors(from_cell),
+                    visibility_of_interest,
+                    points_of_interest,
+                })
+            }
+        };
+
+        NeighborhoodGraphEdges {
+            grid: &self.visibility.grid,
+            agent_diameter,
+            from_cell,
+            from_point,
+            neighborhood,
+        }
+
+        // [from_cell]
+        //     .into_iter()
+        //     .filter(move |_| {
+        //         // dbg!(from_cell);
+        //         self.visibility
+        //             .grid()
+        //             .is_square_occupied(from_p, 2.0 * self.visibility.agent_radius())
+        //             .is_none()
+        //     })
+        //     .flat_map(move |_| {
+        //         // dbg!(from_cell);
+        //         self.visibility
+        //             .calculate_visibility(from_cell)
+        //             .filter(move |to_cell| {
+        //                 // dbg!(to_cell);
+        //                 // Ignore adjacent cells because those will be given by the
+        //                 // neighbors iterator below. If we repeat the same cell twice,
+        //                 // we force the search queue to do unnecessary work.
+        //                 (to_cell.x - from_cell.x).abs() > 1 || (to_cell.y - from_cell.y).abs() > 1
+        //             })
+        //             .map(move |to_cell| (from_cell, to_cell))
+        //             .chain(
+        //                 self.visibility
+        //                     .neighbors(from_cell)
+        //                     .map(move |to_cell| (from_cell, to_cell))
+        //                     .filter(|(from_cell, to_cell)| {
+        //                         // dbg!((from_cell, to_cell));
+        //                         // dbg!(from_cell != to_cell)
+        //                         from_cell != to_cell
+        //                     }),
+        //             )
+        //             .chain({
+        //                 let interest = self.visibility_of_interest.get(&from_cell);
+        //                 interest
+        //                     .into_iter()
+        //                     .flat_map(|x| x)
+        //                     .map(move |point_of_interest| (from_cell, *point_of_interest))
+        //                     .chain([interest].into_iter().filter(|x| x.is_none()).flat_map(
+        //                         move |_| {
+        //                             self.points_of_interest
+        //                                 .iter()
+        //                                 .filter(move |poi| {
+        //                                     let to_p = poi
+        //                                         .center_point(self.visibility.grid().cell_size());
+        //                                     self.visibility
+        //                                         .grid()
+        //                                         .is_sweep_occupied(
+        //                                             from_p,
+        //                                             to_p,
+        //                                             2.0 * self.visibility.agent_radius(),
+        //                                         )
+        //                                         .is_none()
+        //                                 })
+        //                                 .map(move |poi| (from_cell.clone(), *poi))
+        //                         },
+        //                     ))
+        //             })
+        //     })
     }
 
-    type LazyEdgeIter<'a>
-        = Option<(Cell, Cell)>
+    type LazyEdgeIter<'a> = Option<(Cell, Cell)>
     where
         G: 'a;
 
@@ -443,6 +475,83 @@ impl<G: Grid> Graph for NeighborhoodGraph<G> {
     }
 }
 
+impl<G: Grid> Reversible for NeighborhoodGraph<G> {
+    type ReversalError = NoError;
+    fn reversed(&self) -> Result<Self, Self::ReversalError> {
+        // Visibility graphs are always bidirectional, so the reverse is the
+        // same as the forward.
+        Ok(self.clone())
+    }
+}
+
+pub struct NeighborhoodGraphEdges<'a, G: Grid> {
+    grid: &'a G,
+    agent_diameter: f64,
+    from_cell: Cell,
+    from_point: Point,
+    neighborhood: Option<NeighborhoodGraphEdgesIters<'a, G>>,
+}
+
+struct NeighborhoodGraphEdgesIters<'a, G: Grid> {
+    visible_cells: VisibleCells<'a, G>,
+    neighbors: NeighborsIter<'a, G>,
+    visibility_of_interest: Option<HashSetIter<'a, Cell>>,
+    points_of_interest: Option<HashSetIter<'a, Cell>>,
+}
+
+impl<'a, G: Grid> Iterator for NeighborhoodGraphEdges<'a, G> {
+    type Item = (Cell, Cell);
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(neighborhood) = self.neighborhood.as_mut() else {
+            return None;
+        };
+
+        let from_cell = self.from_cell;
+
+        loop {
+            if let Some(to_cell) = neighborhood.visible_cells.next() {
+                if (to_cell.x - from_cell.x).abs() <= 1 && (to_cell.y - from_cell.y).abs() <= 1 {
+                    // Ignore adjacent cells because those will be given by the
+                    // neighbors iterator below. If we repeat the same cell twice,
+                    // we force the search queue to do unnecessary work.
+                    continue;
+                }
+
+                return Some((from_cell, to_cell));
+            }
+
+            if let Some(to_cell) = neighborhood.neighbors.next() {
+                if from_cell == to_cell {
+                    // Skip if it's the same cell that we started from
+                    continue;
+                }
+
+                return Some((from_cell, to_cell));
+            }
+
+            if let Some(visibility_of_interest) = neighborhood.visibility_of_interest.as_mut() {
+                if let Some(visible_point) = visibility_of_interest.next() {
+                    return Some((from_cell, *visible_point));
+                }
+            }
+
+            if let Some(points_of_interest) = neighborhood.points_of_interest.as_mut() {
+                if let Some(point_of_interest) = points_of_interest.next() {
+                    let to_point = point_of_interest.center_point(self.grid.cell_size());
+                    if self.grid.is_sweep_occupied(self.from_point, to_point, self.agent_diameter).is_some() {
+                        // Ignore this point since it does not have visibility
+                        continue;
+                    }
+
+                    return Some((from_cell, *point_of_interest));
+                }
+            }
+
+            return None;
+        }
+    }
+}
+
 impl Edge<Cell, ()> for (Cell, Cell) {
     fn from_vertex(&self) -> &Cell {
         &self.0
@@ -454,15 +563,6 @@ impl Edge<Cell, ()> for (Cell, Cell) {
 
     fn attributes(&self) -> &() {
         &()
-    }
-}
-
-impl<G: Grid> Reversible for NeighborhoodGraph<G> {
-    type ReversalError = NoError;
-    fn reversed(&self) -> Result<Self, Self::ReversalError> {
-        // Visibility graphs are always bidirectional, so the reverse is the
-        // same as the forward.
-        Ok(self.clone())
     }
 }
 

--- a/mapf/src/graph/simple.rs
+++ b/mapf/src/graph/simple.rs
@@ -111,7 +111,8 @@ impl<V, E> Graph for SimpleGraph<V, E> {
         Self::Key: 'a,
         Self::EdgeAttributes: 'a;
 
-    type EdgeIter<'a> = SimpleGraphEdges<'a, E>
+    type EdgeIter<'a>
+        = SimpleGraphEdges<'a, E>
     where
         V: 'a,
         E: 'a;
@@ -157,11 +158,7 @@ impl<'a, E> Iterator for SimpleGraphEdges<'a, E> {
         let from_key = self.from_key;
         self.edges
             .as_mut()
-            .map(|edges| {
-                edges
-                    .next()
-                    .map(|(to_key, attr)| (from_key, *to_key, attr))
-            })
+            .map(|edges| edges.next().map(|(to_key, attr)| (from_key, *to_key, attr)))
             .flatten()
     }
 }

--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -14,11 +14,6 @@
  * limitations under the License.
  *
 */
-#![feature(
-    type_alias_impl_trait,
-    impl_trait_in_assoc_type,
-    result_flattening
-)]
 
 extern crate self as mapf;
 

--- a/mapf/src/lib.rs
+++ b/mapf/src/lib.rs
@@ -15,16 +15,12 @@
  *
 */
 #![feature(
-    associated_type_bounds,
     type_alias_impl_trait,
     impl_trait_in_assoc_type,
     result_flattening
 )]
-// TODO(@mxgrey): Eliminate the need for this by reducing the complexity of
-// struct names, e.g. the typename for the complex chain that implements Lifted
-// in activity.rs. This will probably go hand-in-hand with removing the need for
-// nightly features, and improve compile times all at once.
-#![type_length_limit = "157633981"]
+
+extern crate self as mapf;
 
 pub mod domain;
 

--- a/mapf/src/motion/environment.rs
+++ b/mapf/src/motion/environment.rs
@@ -25,6 +25,8 @@ use crate::{
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
+    iter::Enumerate,
+    slice::Iter as SliceIter,
 };
 
 type Vector2 = nalgebra::Vector2<f64>;
@@ -50,8 +52,7 @@ pub struct DynamicEnvironment<W: Waypoint> {
 impl<W: Waypoint> Environment<CircularProfile, DynamicCircularObstacle<W>>
     for DynamicEnvironment<W>
 {
-    type Obstacles<'a>
-        = impl Iterator<Item = &'a DynamicCircularObstacle<W>>
+    type Obstacles<'a> = SliceIter<'a, DynamicCircularObstacle<W>>
     where
         W: 'a;
 
@@ -319,8 +320,7 @@ impl<'a, W: Waypoint, K> Copy for CcbsEnvironmentView<'a, W, K> {}
 impl<'e, W: Waypoint, K: Key> Environment<CircularProfile, DynamicCircularObstacle<W>>
     for CcbsEnvironmentView<'e, W, K>
 {
-    type Obstacles<'a>
-        = impl Iterator<Item = &'a DynamicCircularObstacle<W>>
+    type Obstacles<'a> = CcbsEnvironmentObstaclesIter<'a, W>
     where
         W: 'a,
         K: 'a,
@@ -335,25 +335,43 @@ impl<'e, W: Waypoint, K: Key> Environment<CircularProfile, DynamicCircularObstac
     }
 
     fn obstacles<'a>(&'a self) -> Self::Obstacles<'a> {
-        self.view
-            .base
-            .obstacles
-            .iter()
-            .enumerate()
-            .map(|(i, obs)| self.view.overlay.obstacles.get(&i).unwrap_or(obs))
-            .chain(
-                self.constraints
-                    .iter()
-                    .flat_map(|x| *x)
-                    .filter_map(|constraint| {
-                        if let Some(mask) = self.view.mask {
-                            if constraint.mask == mask {
-                                return None;
-                            }
-                        }
-                        Some(&constraint.obstacle)
-                    }),
-            )
+        CcbsEnvironmentObstaclesIter {
+            obstacle_overlay: &self.view.overlay.obstacles,
+            mask: self.view.mask,
+            obstacles: self.view.base.obstacles.iter().enumerate(),
+            constraints: self.constraints.as_ref().map(|obs| obs.iter()),
+        }
+    }
+}
+
+pub struct CcbsEnvironmentObstaclesIter<'a, W: Waypoint> {
+    obstacle_overlay: &'a HashMap<usize, DynamicCircularObstacle<W>>,
+    mask: Option<usize>,
+    obstacles: Enumerate<SliceIter<'a, DynamicCircularObstacle<W>>>,
+    constraints: Option<SliceIter<'a, CcbsConstraint<W>>>,
+}
+
+impl<'a, W: Waypoint> Iterator for CcbsEnvironmentObstaclesIter<'a, W> {
+    type Item = &'a DynamicCircularObstacle<W>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((i, obs)) = self.obstacles.next() {
+            return Some(self.obstacle_overlay.get(&i).unwrap_or(obs));
+        }
+
+        loop {
+            if let Some(constraint) = self.constraints.as_mut().map(|c| c.next()).flatten() {
+                if let Some(mask) = self.mask {
+                    if constraint.mask == mask {
+                        // Skip this one since it's masked
+                        continue;
+                    }
+                }
+
+                return Some(&constraint.obstacle);
+            }
+
+            return None;
+        }
     }
 }
 

--- a/mapf/src/motion/environment.rs
+++ b/mapf/src/motion/environment.rs
@@ -24,9 +24,9 @@ use crate::{
 };
 use std::{
     collections::{hash_map::Entry, HashMap},
-    sync::Arc,
     iter::Enumerate,
     slice::Iter as SliceIter,
+    sync::Arc,
 };
 
 type Vector2 = nalgebra::Vector2<f64>;
@@ -52,7 +52,8 @@ pub struct DynamicEnvironment<W: Waypoint> {
 impl<W: Waypoint> Environment<CircularProfile, DynamicCircularObstacle<W>>
     for DynamicEnvironment<W>
 {
-    type Obstacles<'a> = SliceIter<'a, DynamicCircularObstacle<W>>
+    type Obstacles<'a>
+        = SliceIter<'a, DynamicCircularObstacle<W>>
     where
         W: 'a;
 
@@ -320,7 +321,8 @@ impl<'a, W: Waypoint, K> Copy for CcbsEnvironmentView<'a, W, K> {}
 impl<'e, W: Waypoint, K: Key> Environment<CircularProfile, DynamicCircularObstacle<W>>
     for CcbsEnvironmentView<'e, W, K>
 {
-    type Obstacles<'a> = CcbsEnvironmentObstaclesIter<'a, W>
+    type Obstacles<'a>
+        = CcbsEnvironmentObstaclesIter<'a, W>
     where
         W: 'a,
         K: 'a,

--- a/mapf/src/motion/r2/direct_travel.rs
+++ b/mapf/src/motion/r2/direct_travel.rs
@@ -78,7 +78,7 @@ where
                     .transpose()
                     .map(|x| x.flatten())
             })
-            .flatten()
+            .and_then(|x| x)
     }
 }
 

--- a/mapf/src/motion/r2/line_follow.rs
+++ b/mapf/src/motion/r2/line_follow.rs
@@ -33,7 +33,7 @@ use crate::{
     },
 };
 use arrayvec::ArrayVec;
-use smallvec::{SmallVec, smallvec};
+use smallvec::{smallvec, SmallVec};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineFollow {
@@ -197,7 +197,8 @@ where
     K: Key + Clone,
 {
     type AvoidanceAction = SmallVec<[SafeAction<WaypointR2, WaitForObstacle>; 5]>;
-    type AvoidanceActionIter<'a> = SmallVec<[Result<(Self::AvoidanceAction, WaypointR2), Self::AvoidanceError>; 8]>
+    type AvoidanceActionIter<'a>
+        = SmallVec<[Result<(Self::AvoidanceAction, WaypointR2), Self::AvoidanceError>; 8]>
     where
         Target: 'a,
         Guidance: 'a,
@@ -231,20 +232,14 @@ where
         ) {
             Ok(extrapolation) => extrapolation.1,
             Err(err) => {
-                return smallvec![
-                    Err(SafeIntervalMotionError::Extrapolator(err))
-                ];
+                return smallvec![Err(SafeIntervalMotionError::Extrapolator(err))];
             }
         };
 
         let mut safe_arrival_times = match target_key {
             Some(target_key) => match safe_intervals.safe_intervals_for(&target_key) {
                 Ok(r) => r,
-                Err(err) => {
-                    return smallvec![
-                        Err(SafeIntervalMotionError::Cache(err))
-                    ]
-                }
+                Err(err) => return smallvec![Err(SafeIntervalMotionError::Cache(err))],
             },
             None => SafeArrivalTimes::new(),
         };

--- a/mapf/src/motion/safe_interval.rs
+++ b/mapf/src/motion/safe_interval.rs
@@ -328,6 +328,11 @@ impl<T> ClosedIntervals<T> {
         prior.into()
     }
 
+    // This had been used for a method in the ClosedSet trait that allows
+    // debuggers to iterate over all items in the closed set. That method was
+    // removed to ease the migration to the stable toolchain, but we might
+    // bring it back in the future, so we leave this as unused for now.
+    #[allow(unused)]
     fn values<'a>(&'a self) -> ClosedIntervalsValuesIter<'a, T> {
         ClosedIntervalsValuesIter {
             indefinite_start: self.indefinite_start.as_ref(),

--- a/mapf/src/motion/safe_interval.rs
+++ b/mapf/src/motion/safe_interval.rs
@@ -234,55 +234,6 @@ where
             None => ClosedStatus::Open,
         }
     }
-
-    type ClosedSetIter<'a> = SafeIntervalClosedSetIter<'a, Ring::Key, T>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a;
-
-    fn iter_closed<'a>(&'a self) -> SafeIntervalClosedSetIter<'a, Ring::Key, T>
-    where
-        Self: 'a,
-        State: 'a,
-        T: 'a,
-    {
-        // self.container.values().flat_map(|c| c.iter())
-        SafeIntervalClosedSetIter {
-            values: self.container.values(),
-            current_iter: None,
-        }
-    }
-}
-
-pub struct SafeIntervalClosedSetIter<'a, Key, T> {
-    values: std::collections::hash_map::Values<'a, Key, ClosedIntervals<T>>,
-    current_iter: Option<ClosedIntervalsValuesIter<'a, T>>,
-}
-
-impl<'a, Key, T> Iterator for SafeIntervalClosedSetIter<'a, Key, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(current_iter) = &mut self.current_iter {
-                if let Some(next) = current_iter.next() {
-                    return Some(next);
-                }
-            }
-
-            // The current iter ran out of values. Try getting a new one.
-            match self.values.next() {
-                Some(next_intervals) => {
-                    self.current_iter = Some(next_intervals.values());
-                }
-                None => {
-                    // There are no more intervals left.
-                    return None;
-                }
-            }
-        }
-    }
 }
 
 struct ClosedIntervals<T> {

--- a/mapf/src/motion/se2/differential_drive_line_follow.rs
+++ b/mapf/src/motion/se2/differential_drive_line_follow.rs
@@ -33,10 +33,9 @@ use crate::{
         CcbsEnvironment, Duration, MaybeTimed, SafeArrivalTimes, SafeIntervalCache,
         SafeIntervalMotionError, SpeedLimiter, Timed,
     },
-    util::ForkIter,
 };
 use arrayvec::ArrayVec;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 use std::{borrow::Borrow, sync::Arc};
 use time_point::TimePoint;
 
@@ -383,9 +382,7 @@ where
     G::Vertex: Positioned,
 {
     type AvoidanceAction = SmallVec<[SafeAction<WaypointSE2, WaitForObstacle>; 5]>;
-    type AvoidanceActionIter<'a>
-        = impl IntoIterator<Item = Result<(Self::AvoidanceAction, WaypointSE2), Self::AvoidanceError>>
-        + 'a
+    type AvoidanceActionIter<'a> = SmallVec<[Result<(Self::AvoidanceAction, WaypointSE2), Self::AvoidanceError>; 8]>
     where
         Target: 'a,
         Guidance: 'a,
@@ -417,9 +414,7 @@ where
             Some(target_key) => match safe_intervals.safe_intervals_for(&target_key) {
                 Ok(r) => r,
                 Err(err) => {
-                    return ForkIter::Left(
-                        Some(Err(SafeIntervalMotionError::Cache(err))).into_iter(),
-                    )
+                    return smallvec![Err(SafeIntervalMotionError::Cache(err))];
                 }
             },
             None => SafeArrivalTimes::new(),
@@ -437,9 +432,7 @@ where
         {
             Ok(arrival) => arrival,
             Err(err) => {
-                return ForkIter::Left(
-                    Some(Err(SafeIntervalMotionError::Extrapolator(err))).into_iter(),
-                )
+                return smallvec![Err(SafeIntervalMotionError::Extrapolator(err))];
             }
         };
 
@@ -450,14 +443,14 @@ where
             if !is_safe_segment((&from_state.clone().into(), &wp0), None, &environment_view) {
                 // We cannot rotate to face the target, so there is no way to
                 // avoid conflicts from the start state.
-                return ForkIter::Left(None.into_iter());
+                return smallvec![];
             }
         }
 
         let to_position = match arrival.waypoints.last() {
             Some(p) => *p,
             // No motion is needed, the agent is already on the target
-            None => return ForkIter::Left(Some(Ok((SmallVec::new(), *from_state))).into_iter()),
+            None => return smallvec![Ok((SmallVec::new(), *from_state))],
         };
 
         let maybe_oriented = to_target.maybe_oriented();
@@ -471,7 +464,7 @@ where
         // Add the time when the agent would normally arrive at the vertex.
         safe_arrival_times.insert(0, to_position.time);
 
-        let paths: SmallVec<[_; 5]> = safe_arrival_times
+        let paths: SmallVec<[_; 8]> = safe_arrival_times
             .into_iter()
             .filter_map(move |arrival_time| {
                 compute_safe_arrival_path(
@@ -527,7 +520,7 @@ where
             })
             .collect();
 
-        ForkIter::Right(paths.into_iter())
+        paths
     }
 }
 

--- a/mapf/src/motion/se2/differential_drive_line_follow.rs
+++ b/mapf/src/motion/se2/differential_drive_line_follow.rs
@@ -35,7 +35,7 @@ use crate::{
     },
 };
 use arrayvec::ArrayVec;
-use smallvec::{SmallVec, smallvec};
+use smallvec::{smallvec, SmallVec};
 use std::{borrow::Borrow, sync::Arc};
 use time_point::TimePoint;
 
@@ -382,7 +382,8 @@ where
     G::Vertex: Positioned,
 {
     type AvoidanceAction = SmallVec<[SafeAction<WaypointSE2, WaitForObstacle>; 5]>;
-    type AvoidanceActionIter<'a> = SmallVec<[Result<(Self::AvoidanceAction, WaypointSE2), Self::AvoidanceError>; 8]>
+    type AvoidanceActionIter<'a>
+        = SmallVec<[Result<(Self::AvoidanceAction, WaypointSE2), Self::AvoidanceError>; 8]>
     where
         Target: 'a,
         Guidance: 'a,

--- a/mapf/src/motion/se2/space.rs
+++ b/mapf/src/motion/se2/space.rs
@@ -420,7 +420,8 @@ where
     StateSE2<G::Key, R>: Into<State>,
 {
     type InitialError = InitializeSE2Error<G::Key>;
-    type InitialStates<'a> = ForkIter<
+    type InitialStates<'a>
+        = ForkIter<
         StarburstInitialStates<'a, G, R, State>,
         IterError<State, InitializeSE2Error<G::Key>>,
     >
@@ -443,19 +444,19 @@ where
         let from_key: G::Key = from_start.borrow().clone();
         let to_key: &G::Key = to_goal.borrow();
         let Some(from_vertex_ref) = self.graph.vertex(&from_key) else {
-            return ForkIter::Right(
-                IterError::new(InitializeSE2Error::MissingVertex(from_key))
-            );
+            return ForkIter::Right(IterError::new(InitializeSE2Error::MissingVertex(from_key)));
         };
 
         let explicit_edges = self.graph.edges_from_vertex(&from_key).into_iter();
         let lazy_edges = self.graph.lazy_edges_between(&from_key, to_key).into_iter();
-        let explicit_reverse = self.reverse.as_ref().map(
-            |r| r.edges_from_vertex(&from_key).into_iter()
-        );
-        let lazy_reverse = self.reverse.as_ref().map(
-            |r| r.lazy_edges_between(&from_key, to_key).into_iter()
-        );
+        let explicit_reverse = self
+            .reverse
+            .as_ref()
+            .map(|r| r.edges_from_vertex(&from_key).into_iter());
+        let lazy_reverse = self
+            .reverse
+            .as_ref()
+            .map(|r| r.lazy_edges_between(&from_key, to_key).into_iter());
 
         ForkIter::Left(StarburstInitialStates {
             graph: &self.graph,
@@ -501,16 +502,14 @@ where
     G::Key: Clone,
     G::Vertex: Positioned,
 {
-    fn make_waypoint(
-        &self,
-        to_vertex: G::VertexRef<'a>,
-    ) -> (Point, f64) {
+    fn make_waypoint(&self, to_vertex: G::VertexRef<'a>) -> (Point, f64) {
         let from_p: Point = self.from_vertex_ref.borrow().point();
         let to_p: Point = to_vertex.borrow().point();
-        let angle = self.direction * (to_p - from_p)
-            .try_normalize(1e-8)
-            .map(|v| f64::atan2(v[1], v[0]))
-            .unwrap_or(0.0);
+        let angle = self.direction
+            * (to_p - from_p)
+                .try_normalize(1e-8)
+                .map(|v| f64::atan2(v[1], v[0]))
+                .unwrap_or(0.0);
         (from_p, angle)
     }
 
@@ -518,7 +517,9 @@ where
         &self,
         edge: G::Edge<'a>,
     ) -> Result<StateSE2<G::Key, R>, InitializeSE2Error<G::Key>> {
-        let to_vertex = self.graph.vertex(edge.to_vertex())
+        let to_vertex = self
+            .graph
+            .vertex(edge.to_vertex())
             .ok_or_else(|| InitializeSE2Error::MissingVertex(edge.to_vertex().clone()))?;
         let (point, angle) = self.make_waypoint(to_vertex);
         Ok(StateSE2::new(
@@ -527,9 +528,7 @@ where
         ))
     }
 
-    fn next_edge(
-        &mut self
-    ) -> Option<G::Edge<'a>> {
+    fn next_edge(&mut self) -> Option<G::Edge<'a>> {
         if let Some(edge) = self.explicit_edges.next() {
             return Some(edge);
         }
@@ -559,7 +558,8 @@ where
     Goal: Borrow<G::Key> + Clone,
 {
     type ArrivalKeyError = InitializeSE2Error<G::Key>;
-    type ArrivalKeys<'a> = ForkIter<
+    type ArrivalKeys<'a>
+        = ForkIter<
         StarburstInitialStates<'a, G, R, KeySE2<G::Key, R>>,
         IterError<KeySE2<G::Key, R>, InitializeSE2Error<G::Key>>,
     >
@@ -630,7 +630,8 @@ where
     StateSE2<G::Key, R>: Into<State>,
 {
     type InitialError = InitializeSE2Error<G::Key>;
-    type InitialStates<'a> = SmallVec<[Result<State, Self::InitialError>; 16]>
+    type InitialStates<'a>
+        = SmallVec<[Result<State, Self::InitialError>; 16]>
     where
         Self: 'a,
         G: 'a,
@@ -653,7 +654,7 @@ where
             Initializable::<_, _, StateSE2<G::Key, R>>::initialize(
                 &self.starburst,
                 from_start,
-                to_goal
+                to_goal,
             )
             .collect();
 
@@ -693,8 +694,6 @@ where
     }
 }
 
-
-
 impl<G: Graph, const R: u32> ArrivalKeyring<KeySE2<G::Key, R>, G::Key, KeySE2<G::Key, R>>
     for PreferentialStarburstSE2<G, R>
 where
@@ -702,7 +701,8 @@ where
     G::Vertex: Positioned,
 {
     type ArrivalKeyError = InitializeSE2Error<G::Key>;
-    type ArrivalKeys<'a> = SmallVec<[Result<KeySE2<G::Key, R>, Self::ArrivalKeyError>; 16]>
+    type ArrivalKeys<'a>
+        = SmallVec<[Result<KeySE2<G::Key, R>, Self::ArrivalKeyError>; 16]>
     where
         Self: 'a,
         G: 'a,

--- a/mapf/src/templates/conflict_avoidance.rs
+++ b/mapf/src/templates/conflict_avoidance.rs
@@ -40,9 +40,7 @@ where
 {
     type Extrapolation = Avoider::AvoidanceAction;
     type ExtrapolationError = Avoider::AvoidanceError;
-    type ExtrapolationIter<'a>
-        = impl Iterator<Item = Result<(Avoider::AvoidanceAction, State), Self::ExtrapolationError>>
-        + 'a
+    type ExtrapolationIter<'a> = Avoider::AvoidanceActionIter<'a>
     where
         Self: 'a,
         Self::Extrapolation: 'a,
@@ -76,6 +74,5 @@ where
                 for_keys,
                 &*self.environment,
             )
-            .into_iter()
     }
 }

--- a/mapf/src/templates/conflict_avoidance.rs
+++ b/mapf/src/templates/conflict_avoidance.rs
@@ -40,7 +40,8 @@ where
 {
     type Extrapolation = Avoider::AvoidanceAction;
     type ExtrapolationError = Avoider::AvoidanceError;
-    type ExtrapolationIter<'a> = Avoider::AvoidanceActionIter<'a>
+    type ExtrapolationIter<'a>
+        = Avoider::AvoidanceActionIter<'a>
     where
         Self: 'a,
         Self::Extrapolation: 'a,
@@ -66,13 +67,12 @@ where
         Guidance: 'a,
         Key: 'a,
     {
-        self.avoider
-            .avoid_conflicts(
-                from_state,
-                to_target,
-                with_guidance,
-                for_keys,
-                &*self.environment,
-            )
+        self.avoider.avoid_conflicts(
+            from_state,
+            to_target,
+            with_guidance,
+            for_keys,
+            &*self.environment,
+        )
     }
 }

--- a/mapf/src/templates/graph_motion.rs
+++ b/mapf/src/templates/graph_motion.rs
@@ -81,14 +81,14 @@ where
     E: Extrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
     E::ExtrapolationError: StdError,
 {
-    type ActivityAction = E::Extrapolation;
+    type Action = E::Extrapolation;
     type ActivityError = GraphMotionError<G::Key, E::ExtrapolationError>;
     type Choices<'a>
         =
-        impl IntoIterator<Item = Result<(Self::ActivityAction, S::State), Self::ActivityError>> + 'a
+        impl IntoIterator<Item = Result<(Self::Action, S::State), Self::ActivityError>> + 'a
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         S::State: 'a,
         G::EdgeAttributes: 'a,
@@ -98,7 +98,7 @@ where
     fn choices<'a>(&'a self, from_state: S::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         S::State: 'a,
         G::Key: 'a,

--- a/mapf/src/templates/graph_motion.rs
+++ b/mapf/src/templates/graph_motion.rs
@@ -82,7 +82,8 @@ where
 {
     type Action = E::Extrapolation;
     type ActivityError = GraphMotionError<G::Key, E::ExtrapolationError>;
-    type Choices<'a> = GraphMotionChoices<'a, S, G, E>
+    type Choices<'a>
+        = GraphMotionChoices<'a, S, G, E>
     where
         Self: 'a,
         Self::Action: 'a,
@@ -231,7 +232,8 @@ where
     E: Extrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
     E::ExtrapolationError: StdError,
 {
-    current_iter: Option<Extrapolations<G::Key, <E::ExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
+    current_iter:
+        Option<Extrapolations<G::Key, <E::ExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
     edges_from_vertex: <G::EdgeIter<'a> as IntoIterator>::IntoIter,
     motion: &'a GraphMotion<S, G, E>,
     from_state: S::State,
@@ -248,7 +250,8 @@ where
     E: Extrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
     E::ExtrapolationError: StdError,
 {
-    type Item = Result<(E::Extrapolation, S::State), GraphMotionError<G::Key, E::ExtrapolationError>>;
+    type Item =
+        Result<(E::Extrapolation, S::State), GraphMotionError<G::Key, E::ExtrapolationError>>;
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current_iter) = self.current_iter.as_mut() {
@@ -278,7 +281,13 @@ where
                     v.borrow(),
                     &edge.attributes(),
                     (
-                        Some(self.motion.space.key_for(&self.from_state).borrow().borrow()),
+                        Some(
+                            self.motion
+                                .space
+                                .key_for(&self.from_state)
+                                .borrow()
+                                .borrow(),
+                        ),
                         Some(&to_vertex),
                     ),
                 );
@@ -294,7 +303,6 @@ where
 
             return None;
         }
-
     }
 }
 

--- a/mapf/src/templates/incremental_graph_motion.rs
+++ b/mapf/src/templates/incremental_graph_motion.rs
@@ -90,18 +90,18 @@ where
     E: IncrementalExtrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
     E::IncrementalExtrapolationError: StdError,
 {
-    type ActivityAction = E::IncrementalExtrapolation;
+    type Action = E::IncrementalExtrapolation;
     type ActivityError = GraphMotionError<G::Key, E::IncrementalExtrapolationError>;
     type Choices<'a>
         = impl IntoIterator<
             Item = Result<
-                (Self::ActivityAction, IncrementalState<S::State, G>),
+                (Self::Action, IncrementalState<S::State, G>),
                 Self::ActivityError,
             >,
         > + 'a
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         S::State: 'a,
         G::EdgeAttributes: 'a;
@@ -109,7 +109,7 @@ where
     fn choices<'a>(&'a self, from_state: IncrementalState<S::State, G>) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         IncrementalState<S::State, G>: 'a,
     {

--- a/mapf/src/templates/incremental_graph_motion.rs
+++ b/mapf/src/templates/incremental_graph_motion.rs
@@ -91,7 +91,8 @@ where
 {
     type Action = E::IncrementalExtrapolation;
     type ActivityError = GraphMotionError<G::Key, E::IncrementalExtrapolationError>;
-    type Choices<'a> = IncrementalGraphMotionChoices<'a, S, G, E>
+    type Choices<'a>
+        = IncrementalGraphMotionChoices<'a, S, G, E>
     where
         Self: 'a,
         Self::Action: 'a,
@@ -118,13 +119,10 @@ where
         } else {
             // No specific target, so we want to expand in every direction from
             // this vertex.
-            let edges_from_vertex = self.graph.edges_from_vertex(
-                self.space
-                    .key_for(&from_state.base_state)
-                    .borrow()
-                    .borrow()
-            )
-            .into_iter();
+            let edges_from_vertex = self
+                .graph
+                .edges_from_vertex(self.space.key_for(&from_state.base_state).borrow().borrow())
+                .into_iter();
 
             IncrementalGraphMotionChoices {
                 current_iter: None,
@@ -265,7 +263,13 @@ where
     G: Graph,
     E: IncrementalExtrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
 {
-    current_iter: Option<Extrapolations<G::Key, G::EdgeAttributes, <E::IncrementalExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
+    current_iter: Option<
+        Extrapolations<
+            G::Key,
+            G::EdgeAttributes,
+            <E::IncrementalExtrapolationIter<'a> as IntoIterator>::IntoIter,
+        >,
+    >,
     next_target: Option<(G::Key, G::EdgeAttributes)>,
     edges_from_vertex: Option<<G::EdgeIter<'a> as IntoIterator>::IntoIter>,
     motion: &'a IncrementalGraphMotion<S, G, E>,
@@ -337,7 +341,13 @@ where
                     to_v_ref.borrow(),
                     &with_guidance,
                     (
-                        Some(self.motion.space.key_for(&self.from_base_state).borrow().borrow()),
+                        Some(
+                            self.motion
+                                .space
+                                .key_for(&self.from_base_state)
+                                .borrow()
+                                .borrow(),
+                        ),
                         Some(&to_key),
                     ),
                 );

--- a/mapf/src/templates/informed_search.rs
+++ b/mapf/src/templates/informed_search.rs
@@ -295,7 +295,8 @@ where
 {
     type Action = A::Action;
     type ActivityError = A::ActivityError;
-    type Choices<'a> = A::Choices<'a>
+    type Choices<'a>
+        = A::Choices<'a>
     where
         Self: 'a,
         Self::Action: 'a,
@@ -313,8 +314,7 @@ where
     }
 }
 
-impl<A, W, H, X, I, S, C> Weighted<A::State, A::Action>
-    for InformedSearch<A, W, H, X, I, S, C>
+impl<A, W, H, X, I, S, C> Weighted<A::State, A::Action> for InformedSearch<A, W, H, X, I, S, C>
 where
     A: Domain + Activity<A::State>,
     W: Weighted<A::State, A::Action>,
@@ -381,7 +381,8 @@ where
     C::ConnectionError: Into<Anyhow>,
 {
     type ConnectionError = C::ConnectionError;
-    type Connections<'a> = C::Connections<'a>
+    type Connections<'a>
+        = C::Connections<'a>
     where
         Self: 'a,
         Self::ConnectionError: 'a,
@@ -434,7 +435,8 @@ where
     S: ArrivalKeyring<A::Key, Start, Goal>,
 {
     type ArrivalKeyError = S::ArrivalKeyError;
-    type ArrivalKeys<'a> = S::ArrivalKeys<'a>
+    type ArrivalKeys<'a>
+        = S::ArrivalKeys<'a>
     where
         Self: 'a,
         Start: 'a,
@@ -508,8 +510,7 @@ where
     }
 }
 
-impl<A, W, H, X, I, S, C> Backtrack<A::State, A::Action>
-    for InformedSearch<A, W, H, X, I, S, C>
+impl<A, W, H, X, I, S, C> Backtrack<A::State, A::Action> for InformedSearch<A, W, H, X, I, S, C>
 where
     A: Domain + Activity<A::State> + Backtrack<A::State, A::Action>,
 {

--- a/mapf/src/templates/informed_search.rs
+++ b/mapf/src/templates/informed_search.rs
@@ -295,9 +295,7 @@ where
 {
     type Action = A::Action;
     type ActivityError = A::ActivityError;
-    type Choices<'a>
-        =
-        impl IntoIterator<Item = Result<(Self::Action, A::State), Self::ActivityError>> + 'a
+    type Choices<'a> = A::Choices<'a>
     where
         Self: 'a,
         Self::Action: 'a,
@@ -382,10 +380,8 @@ where
     C: Connectable<A::State, A::Action, Goal>,
     C::ConnectionError: Into<Anyhow>,
 {
-    type ConnectionError = anyhow::Error;
-    type Connections<'a>
-        =
-        impl IntoIterator<Item = Result<(A::Action, A::State), Self::ConnectionError>> + 'a
+    type ConnectionError = C::ConnectionError;
+    type Connections<'a> = C::Connections<'a>
     where
         Self: 'a,
         Self::ConnectionError: 'a,
@@ -400,10 +396,7 @@ where
         A::Action: 'a,
         Goal: 'a,
     {
-        self.connector
-            .connect(from_state.clone(), to_target)
-            .into_iter()
-            .map(|r| r.map_err(Into::into))
+        self.connector.connect(from_state.clone(), to_target)
     }
 }
 
@@ -441,8 +434,7 @@ where
     S: ArrivalKeyring<A::Key, Start, Goal>,
 {
     type ArrivalKeyError = S::ArrivalKeyError;
-    type ArrivalKeys<'a>
-        = S::ArrivalKeys<'a>
+    type ArrivalKeys<'a> = S::ArrivalKeys<'a>
     where
         Self: 'a,
         Start: 'a,

--- a/mapf/src/templates/informed_search.rs
+++ b/mapf/src/templates/informed_search.rs
@@ -293,21 +293,21 @@ impl<A, W, H, X, I, S, C> Activity<A::State> for InformedSearch<A, W, H, X, I, S
 where
     A: Domain + Activity<A::State>,
 {
-    type ActivityAction = A::ActivityAction;
+    type Action = A::Action;
     type ActivityError = A::ActivityError;
     type Choices<'a>
         =
-        impl IntoIterator<Item = Result<(Self::ActivityAction, A::State), Self::ActivityError>> + 'a
+        impl IntoIterator<Item = Result<(Self::Action, A::State), Self::ActivityError>> + 'a
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         A::State: 'a;
 
     fn choices<'a>(&'a self, from_state: A::State) -> Self::Choices<'a>
     where
         Self: 'a,
-        Self::ActivityAction: 'a,
+        Self::Action: 'a,
         Self::ActivityError: 'a,
         A::State: 'a,
     {
@@ -315,11 +315,11 @@ where
     }
 }
 
-impl<A, W, H, X, I, S, C> Weighted<A::State, A::ActivityAction>
+impl<A, W, H, X, I, S, C> Weighted<A::State, A::Action>
     for InformedSearch<A, W, H, X, I, S, C>
 where
     A: Domain + Activity<A::State>,
-    W: Weighted<A::State, A::ActivityAction>,
+    W: Weighted<A::State, A::Action>,
     W::WeightedError: Into<Anyhow>,
 {
     type Cost = W::Cost;
@@ -327,7 +327,7 @@ where
     fn cost(
         &self,
         from_state: &A::State,
-        action: &A::ActivityAction,
+        action: &A::Action,
         to_state: &A::State,
     ) -> Result<Option<Self::Cost>, Self::WeightedError> {
         self.weight.cost(from_state, action, to_state)
@@ -374,30 +374,30 @@ where
     }
 }
 
-impl<A, W, H, X, I, S, C, Goal> Connectable<A::State, A::ActivityAction, Goal>
+impl<A, W, H, X, I, S, C, Goal> Connectable<A::State, A::Action, Goal>
     for InformedSearch<A, W, H, X, I, S, C>
 where
     A: Domain + Activity<A::State>,
     A::State: Clone,
-    C: Connectable<A::State, A::ActivityAction, Goal>,
+    C: Connectable<A::State, A::Action, Goal>,
     C::ConnectionError: Into<Anyhow>,
 {
     type ConnectionError = anyhow::Error;
     type Connections<'a>
         =
-        impl IntoIterator<Item = Result<(A::ActivityAction, A::State), Self::ConnectionError>> + 'a
+        impl IntoIterator<Item = Result<(A::Action, A::State), Self::ConnectionError>> + 'a
     where
         Self: 'a,
         Self::ConnectionError: 'a,
         A::State: 'a,
-        A::ActivityAction: 'a,
+        A::Action: 'a,
         Goal: 'a;
 
     fn connect<'a>(&'a self, from_state: A::State, to_target: &'a Goal) -> Self::Connections<'a>
     where
         Self::ConnectionError: 'a,
         A::State: 'a,
-        A::ActivityAction: 'a,
+        A::Action: 'a,
         Goal: 'a,
     {
         self.connector
@@ -516,10 +516,10 @@ where
     }
 }
 
-impl<A, W, H, X, I, S, C> Backtrack<A::State, A::ActivityAction>
+impl<A, W, H, X, I, S, C> Backtrack<A::State, A::Action>
     for InformedSearch<A, W, H, X, I, S, C>
 where
-    A: Domain + Activity<A::State> + Backtrack<A::State, A::ActivityAction>,
+    A: Domain + Activity<A::State> + Backtrack<A::State, A::Action>,
 {
     type BacktrackError = A::BacktrackError;
     fn flip_endpoints(
@@ -535,9 +535,9 @@ where
         &self,
         parent_forward_state: &A::State,
         parent_reverse_state: &A::State,
-        reverse_action: &A::ActivityAction,
+        reverse_action: &A::Action,
         child_reverse_state: &A::State,
-    ) -> Result<(A::ActivityAction, A::State), Self::BacktrackError> {
+    ) -> Result<(A::Action, A::State), Self::BacktrackError> {
         self.activity.backtrack(
             parent_forward_state,
             parent_reverse_state,

--- a/mapf/src/templates/lazy_graph_motion.rs
+++ b/mapf/src/templates/lazy_graph_motion.rs
@@ -54,7 +54,8 @@ where
     R: ArrivalKeyring<G::Key, G::Key, Goal>,
     C: Connectable<State, Action, Goal>,
 {
-    type Connections<'a> = LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
+    type Connections<'a>
+        = LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
     where
         Self: 'a,
         Self::ConnectionError: 'a,
@@ -75,13 +76,19 @@ where
         let from_spatial_state = from_state.borrow().clone();
         let from_key_ref = self.motion.space.key_for(&from_spatial_state);
         let from_key = from_key_ref.borrow().borrow();
-        let arrival_keys = self.keyring.get_arrival_keys(&from_key, to_target).into_iter();
+        let arrival_keys = self
+            .keyring
+            .get_arrival_keys(&from_key, to_target)
+            .into_iter();
 
         LazyGraphMotionConnections::<'a, S, G, E, R, C, State, Action, Goal> {
             current_iter: None,
             lazy_edges: None,
             arrival_keys,
-            chained_connections: self.chain.connect(from_state.clone(), to_target).into_iter(),
+            chained_connections: self
+                .chain
+                .connect(from_state.clone(), to_target)
+                .into_iter(),
             motion: &self.motion,
             from_state: from_spatial_state.clone(),
             _ignore: Default::default(),
@@ -143,7 +150,8 @@ where
     Action: 'a,
     Goal: 'a,
 {
-    current_iter: Option<Extrapolations<G::Key, <E::ExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
+    current_iter:
+        Option<Extrapolations<G::Key, <E::ExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
     lazy_edges: Option<<G::LazyEdgeIter<'a> as IntoIterator>::IntoIter>,
     arrival_keys: <R::ArrivalKeys<'a> as IntoIterator>::IntoIter,
     chained_connections: <C::Connections<'a> as IntoIterator>::IntoIter,
@@ -152,7 +160,8 @@ where
     _ignore: std::marker::PhantomData<fn(State, Action)>,
 }
 
-impl<'a, S, G, E, R, C, State, Action, Goal> Iterator for LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
+impl<'a, S, G, E, R, C, State, Action, Goal> Iterator
+    for LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
 where
     S: 'a + KeyedSpace<G::Key>,
     S::Key: 'a + Borrow<G::Key>,
@@ -171,7 +180,10 @@ where
     Action: 'a,
     Goal: 'a,
 {
-    type Item = Result<(Action, State), LazyGraphMotionError<G::Key, R::ArrivalKeyError, E::ExtrapolationError, C::ConnectionError>>;
+    type Item = Result<
+        (Action, State),
+        LazyGraphMotionError<G::Key, R::ArrivalKeyError, E::ExtrapolationError, C::ConnectionError>,
+    >;
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current_iter) = self.current_iter.as_mut() {
@@ -202,7 +214,13 @@ where
                         v.borrow(),
                         &edge.attributes(),
                         (
-                            Some(self.motion.space.key_for(&self.from_state).borrow().borrow()),
+                            Some(
+                                self.motion
+                                    .space
+                                    .key_for(&self.from_state)
+                                    .borrow()
+                                    .borrow(),
+                            ),
                             Some(&to_vertex),
                         ),
                     );

--- a/mapf/src/templates/lazy_graph_motion.rs
+++ b/mapf/src/templates/lazy_graph_motion.rs
@@ -20,7 +20,6 @@ use crate::{
     error::ThisError,
     graph::{Edge, Graph},
     templates::GraphMotion,
-    util::FlatResultMapTrait,
 };
 use std::borrow::Borrow;
 
@@ -55,8 +54,7 @@ where
     R: ArrivalKeyring<G::Key, G::Key, Goal>,
     C: Connectable<State, Action, Goal>,
 {
-    type Connections<'a>
-        = impl Iterator<Item = Result<(Action, State), Self::ConnectionError>> + 'a
+    type Connections<'a> = LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
     where
         Self: 'a,
         Self::ConnectionError: 'a,
@@ -74,77 +72,20 @@ where
         Action: 'a,
         Goal: 'a,
     {
-        let from_spatial_state: S::State = from_state.clone().borrow().clone();
-        let from_key: G::Key = self
-            .motion
-            .space
-            .key_for(&from_spatial_state)
-            .borrow()
-            .borrow()
-            .clone();
-        self.keyring
-            .get_arrival_keys(&from_key, to_target)
-            .into_iter()
-            .flat_map(move |r: Result<G::Key, R::ArrivalKeyError>| {
-                let from_spatial_state = from_spatial_state.clone();
-                let from_key = from_key.clone();
-                r.map_err(LazyGraphMotionError::Keyring)
-                    .flat_result_map(move |to_vertex: G::Key| {
-                        let from_key = from_key.clone();
-                        let from_spatial_state = from_spatial_state.clone();
-                        self.motion
-                            .graph
-                            .lazy_edges_between(&from_key, &to_vertex)
-                            .into_iter()
-                            .flat_map(move |edge| {
-                                let from_key = from_key.clone();
-                                let from_state = from_spatial_state.clone();
-                                let to_vertex = to_vertex.clone();
-                                let edge: G::EdgeAttributes = edge.attributes().clone();
+        let from_spatial_state = from_state.borrow().clone();
+        let from_key_ref = self.motion.space.key_for(&from_spatial_state);
+        let from_key = from_key_ref.borrow().borrow();
+        let arrival_keys = self.keyring.get_arrival_keys(&from_key, to_target).into_iter();
 
-                                self.motion
-                                    .graph
-                                    .vertex(&to_vertex)
-                                    .ok_or_else(|| {
-                                        LazyGraphMotionError::MissingVertex(to_vertex.clone())
-                                    })
-                                    .flat_result_map(move |v| {
-                                        let from_key = from_key.clone();
-                                        let from_state = from_state.clone();
-                                        let to_vertex = to_vertex.clone();
-                                        let extrapolations = self.motion.extrapolator.extrapolate(
-                                            self.motion.space.waypoint(&from_state).borrow(),
-                                            v.borrow(),
-                                            &edge,
-                                            (Some(&from_key), Some(&to_vertex)),
-                                        );
-
-                                        extrapolations.into_iter().map(move |r| {
-                                            let to_vertex = to_vertex.clone();
-                                            r.map_err(LazyGraphMotionError::Extrapolator).map(
-                                                move |(action, waypoint)| {
-                                                    let to_vertex = to_vertex.clone();
-                                                    let state = self.motion.space.make_keyed_state(
-                                                        to_vertex.clone(),
-                                                        waypoint,
-                                                    );
-                                                    (action.into(), state.into())
-                                                },
-                                            )
-                                        })
-                                    })
-                                    .map(|x| x.flatten())
-                            })
-                    })
-                    .map(|x| x.flatten())
-                    .map(|x: Result<(Action, State), Self::ConnectionError>| x)
-            })
-            .chain(
-                self.chain
-                    .connect(from_state, to_target)
-                    .into_iter()
-                    .map(|r| r.map_err(LazyGraphMotionError::Chain)),
-            )
+        LazyGraphMotionConnections::<'a, S, G, E, R, C, State, Action, Goal> {
+            current_iter: None,
+            lazy_edges: None,
+            arrival_keys,
+            chained_connections: self.chain.connect(from_state.clone(), to_target).into_iter(),
+            motion: &self.motion,
+            from_state: from_spatial_state.clone(),
+            _ignore: Default::default(),
+        }
     }
 }
 
@@ -181,6 +122,130 @@ where
                 .map_err(LazyGraphMotionReversalError::Chain)?,
         })
     }
+}
+
+pub struct LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
+where
+    S: 'a + KeyedSpace<G::Key>,
+    S::Key: 'a + Borrow<G::Key>,
+    S::State: 'a + Into<State> + Clone,
+    State: 'a + Borrow<S::State> + Clone,
+    G: 'a + Graph,
+    G::Key: 'a + Clone,
+    G::EdgeAttributes: 'a + Clone,
+    E: 'a + Extrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
+    E::Extrapolation: 'a + Into<Action>,
+    Action: 'a + Into<E::Extrapolation>,
+    R: 'a + ArrivalKeyring<G::Key, G::Key, Goal>,
+    R::ArrivalKeyError: 'a,
+    C: 'a + Connectable<State, Action, Goal>,
+    State: 'a,
+    Action: 'a,
+    Goal: 'a,
+{
+    current_iter: Option<Extrapolations<G::Key, <E::ExtrapolationIter<'a> as IntoIterator>::IntoIter>>,
+    lazy_edges: Option<<G::LazyEdgeIter<'a> as IntoIterator>::IntoIter>,
+    arrival_keys: <R::ArrivalKeys<'a> as IntoIterator>::IntoIter,
+    chained_connections: <C::Connections<'a> as IntoIterator>::IntoIter,
+    motion: &'a GraphMotion<S, G, E>,
+    from_state: S::State,
+    _ignore: std::marker::PhantomData<fn(State, Action)>,
+}
+
+impl<'a, S, G, E, R, C, State, Action, Goal> Iterator for LazyGraphMotionConnections<'a, S, G, E, R, C, State, Action, Goal>
+where
+    S: 'a + KeyedSpace<G::Key>,
+    S::Key: 'a + Borrow<G::Key>,
+    S::State: 'a + Into<State> + Clone,
+    State: 'a + Borrow<S::State> + Clone,
+    G: 'a + Graph,
+    G::Key: 'a + Clone,
+    G::EdgeAttributes: 'a + Clone,
+    E: 'a + Extrapolator<S::Waypoint, G::Vertex, G::EdgeAttributes, G::Key>,
+    E::Extrapolation: 'a + Into<Action>,
+    Action: 'a + Into<E::Extrapolation>,
+    R: 'a + ArrivalKeyring<G::Key, G::Key, Goal>,
+    R::ArrivalKeyError: 'a,
+    C: 'a + Connectable<State, Action, Goal>,
+    State: 'a,
+    Action: 'a,
+    Goal: 'a,
+{
+    type Item = Result<(Action, State), LazyGraphMotionError<G::Key, R::ArrivalKeyError, E::ExtrapolationError, C::ConnectionError>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(current_iter) = self.current_iter.as_mut() {
+                if let Some(result) = current_iter.extrapolations.next() {
+                    match result {
+                        Ok((action, waypoint)) => {
+                            let to_vertex = current_iter.to_vertex.clone();
+                            let state = self.motion.space.make_keyed_state(to_vertex, waypoint);
+                            return Some(Ok((action.into(), state.into())));
+                        }
+                        Err(err) => {
+                            return Some(Err(LazyGraphMotionError::Extrapolator(err)));
+                        }
+                    }
+                }
+            }
+            self.current_iter = None;
+
+            if let Some(lazy_edges) = self.lazy_edges.as_mut() {
+                if let Some(edge) = lazy_edges.next() {
+                    let to_vertex = edge.to_vertex();
+                    let Some(v) = self.motion.graph.vertex(to_vertex) else {
+                        return Some(Err(LazyGraphMotionError::MissingVertex(to_vertex.clone())));
+                    };
+
+                    let extrapolations = self.motion.extrapolator.extrapolate(
+                        self.motion.space.waypoint(&self.from_state).borrow(),
+                        v.borrow(),
+                        &edge.attributes(),
+                        (
+                            Some(self.motion.space.key_for(&self.from_state).borrow().borrow()),
+                            Some(&to_vertex),
+                        ),
+                    );
+
+                    self.current_iter = Some(Extrapolations {
+                        to_vertex: to_vertex.clone(),
+                        extrapolations: extrapolations.into_iter(),
+                    });
+                    // Restart the loop so we can immediately start iterating
+                    // over these extrapolations.
+                    continue;
+                }
+            }
+
+            if let Some(result) = self.arrival_keys.next() {
+                let to_vertex = match result {
+                    Ok(to_vertex) => to_vertex,
+                    Err(err) => {
+                        return Some(Err(LazyGraphMotionError::Keyring(err)));
+                    }
+                };
+
+                let from_key_ref = self.motion.space.key_for(&self.from_state);
+                let from_key = from_key_ref.borrow().borrow();
+                let lazy_edges = self.motion.graph.lazy_edges_between(from_key, &to_vertex);
+                self.lazy_edges = Some(lazy_edges.into_iter());
+                // Restart the loop so we can immediately start iterating over
+                // these lazy edges.
+                continue;
+            }
+
+            if let Some(next_in_chain) = self.chained_connections.next() {
+                return Some(next_in_chain.map_err(LazyGraphMotionError::Chain));
+            }
+
+            return None;
+        }
+    }
+}
+
+struct Extrapolations<K, E> {
+    to_vertex: K,
+    extrapolations: E,
 }
 
 #[derive(Debug, ThisError)]

--- a/mapf/src/util.rs
+++ b/mapf/src/util.rs
@@ -153,3 +153,24 @@ pub fn wrap_to_pi(mut value: f64) -> f64 {
 
     value
 }
+
+pub struct IterError<T, E> {
+    error: Option<E>,
+    _ignore: std::marker::PhantomData<fn(T)>,
+}
+
+impl<T, E> IterError<T, E> {
+    pub fn new(error: E) -> Self {
+        Self {
+            error: Some(error),
+            _ignore: Default::default(),
+        }
+    }
+}
+
+impl<T, E> Iterator for IterError<T, E> {
+    type Item = Result<T, E>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.error.take().map(Err)
+    }
+}

--- a/mapf/src/util.rs
+++ b/mapf/src/util.rs
@@ -81,52 +81,6 @@ impl<T: Clone, F: Fn(&T, &T) -> std::cmp::Ordering> Minimum<T, F> {
     }
 }
 
-pub enum FlatResultMapIter<T, U: IntoIterator, F, E> {
-    Ok(std::iter::FlatMap<std::option::IntoIter<T>, U, F>),
-    Err(Option<E>),
-}
-
-impl<T, U: IntoIterator, F, E> Iterator for FlatResultMapIter<T, U, F, E>
-where
-    F: FnMut(T) -> U,
-{
-    type Item = Result<U::Item, E>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Ok(inner) => Ok(inner.next()).transpose(),
-            Self::Err(inner) => inner.take().map(|e| Err(e)),
-        }
-    }
-}
-
-pub trait FlatResultMapTrait {
-    type Type;
-    type Error;
-    fn flat_result_map<U, F>(self, f: F) -> FlatResultMapIter<Self::Type, U, F, Self::Error>
-    where
-        Self: Sized,
-        U: IntoIterator,
-        F: FnMut(Self::Type) -> U;
-}
-
-impl<T, E> FlatResultMapTrait for Result<T, E> {
-    type Type = T;
-    type Error = E;
-    fn flat_result_map<U, F>(self, f: F) -> FlatResultMapIter<Self::Type, U, F, Self::Error>
-    where
-        Self: Sized,
-        U: IntoIterator,
-        F: FnMut(T) -> U,
-    {
-        match self {
-            Ok(iter) => FlatResultMapIter::Ok(Some(iter).into_iter().flat_map(f)),
-            Err(err) => FlatResultMapIter::Err(Some(err)),
-        }
-    }
-}
-
 pub enum ForkIter<L, R> {
     Left(L),
     Right(R),


### PR DESCRIPTION
For a long time this library has been taking advantage of some unstable language features in the nightly toolchain in order to reduce some boilerplate for implementing custom iterators that get returned by trait interfaces.

The most important language feature that we were depending on, Generic Associated Types, was stabilized two years ago. With that covered on the stable toolchain, I was able to migrate the rest of the implementation to no longer need the nightly toolchain. In some cases this has made the code more verbose, but in other cases the code may actually be less difficult to understand after this migration.

What would probably help the ergonomics of this library the most would be if [generators](https://dev-doc.rust-lang.org/beta/std/ops/trait.Generator.html) were available as a stable language feature, but we are unlikely to see that become available any time soon.