### PR TITLE
fix: Spatial Canvas scaling boundary constraints

### DIFF
--- a/mapf-viz/src/spatial_canvas.rs
+++ b/mapf-viz/src/spatial_canvas.rs
@@ -307,6 +307,7 @@ impl<'a, Message, Program: SpatialCanvasProgram<Message>> canvas::Program<Messag
                             let p_raw = Point::new(p_raw.x, p_raw.y);
                             self.offset =
                                 p_raw - Transform::scale(self.zoom, -self.zoom).transform_point(p0);
+                            self.cache.clear();
                         }
                     }
                 }


### PR DESCRIPTION
## Bug fix

### Fixed bug

https://github.com/open-rmf/mapf/issues/32

When the scaling is too large or too small, the spatial bounds will become very large or very small.

### Fix applied

Scaling boundary constraints: by adding scaling boundary constraints to `SpatialCanvas` (`MIN_ZOOM = 0.001`, `MAX_ZOOM = 1000.0`), we can prevent `spatial_bounds` from becoming abnormally large or abnormally small.

